### PR TITLE
chore: trigger workflow and wait

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -29,16 +29,12 @@ jobs:
           echo "UID=${uid}" >> $GITHUB_ENV
         shell: bash
 
-      - uses: actions/github-script@v6
+      - uses: convictional/trigger-workflow-and-wait@v1.6.1
         with:
-          github-token: ${{ secrets.ROBOT_TOPOSWARE_K8S_E2E_RW }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'toposware',
-              repo: 'k8s-e2e',
-              workflow_id: 'test.yml',
-              ref: 'main',
-              inputs: {
-                uid: '${{ env.UID }}'
-              },
-            })
+          owner: toposware
+          repo: k8s-e2e
+          github_token: ${{ secrets.ROBOT_TOPOSWARE_K8S_E2E_RW }}
+          workflow_file_name: test.yml
+          ref: main
+          wait_interval: 60
+          client_payload: '{ "uid": "${{ env.UID }}"}'

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -24,9 +24,9 @@ jobs:
     steps:
       - name: Set environment
         run: |
-          sha=${{ github.sha }}
-          uid="${sha:0:6}-${{ github.run_number }}"
-          echo "UID=${uid}" >> $GITHUB_ENV
+          # It's fine to assume a single tag. Our tagging strategy follows a 1:1 mapping of image:tag
+          tags=${{ needs.docker.outputs.tags }}
+          echo "docker_tag=${tags#*:}" >> $GITHUB_ENV
         shell: bash
 
       - uses: convictional/trigger-workflow-and-wait@v1.6.1
@@ -37,4 +37,4 @@ jobs:
           workflow_file_name: test.yml
           ref: main
           wait_interval: 60
-          client_payload: '{ "uid": "${{ env.UID }}"}'
+          client_payload: '{ "git_commit": "${{ github.sha }}", "docker_tag": "${{ env.docker_tag }}" }'

--- a/.github/workflows/docker_utils.yml
+++ b/.github/workflows/docker_utils.yml
@@ -22,11 +22,17 @@ on:
         required: false
         type: string
         default: tce,sequencer
+    outputs:
+      tags:
+        description: "Docker tags"
+        value: ${{ jobs.docker.outputs.tags }}
 
 jobs:
   docker:
     name: Build and push docker image to GitHub Container Registry
     runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description
This PR slightly changes the behavior of the `k8s_e2e` step of `Docker_build_push` workflow. Instead of asynchronously executing `k8s-e2e`, we trigger and wait the results of the workflow.

## Additions and Changes

The trigger and wait feature is added by the `convictional/trigger-workflow-and-wait` GitHub action. Waiting for the results of `k8s-e2e` allows us to create a chain of events based on success/failure of e2e tests.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
