### PR TITLE
chore: bring back codecov token

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,4 +36,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.1
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
# Description

Bring back the use of `CODECOV_TOKEN`—although the repo is publi—to prevent rate limiting errors on Github's end. These errors seem to happen when we don't use our own tokens and when codecov use their own ([source](https://github.com/codecov/codecov-action/issues/557#issuecomment-1216749652)).

## Additions and Changes

- Use `CODECOV_TOKEN` from secrets in the `coverage.yml` CI workflow

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
