### PR TITLE
chore: trigger on push to debug branches

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -2,7 +2,7 @@ name: Docker_build_push
 
 on:
   push:
-    branches: [main]
+    branches: [main, debug/**]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
# Description

Trigger `Docker_build_push` on push to `debug/**` branches.

## Test

Created a branch `debug/test-debug-trigger` and verified that the job is triggered:
https://github.com/topos-network/topos/actions/runs/4489864527

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
