### PR TITLE
fix(init.sh): fix the docker setup init file check

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -71,7 +71,7 @@ services:
 
   peer:
     image: ghcr.io/topos-network/topos:main
-    command: tce run
+    command: peer tce run
     init: true
     healthcheck:
       test: ./topos tce push-peer-list --endpoint http://localhost:1340 --format json /tmp/shared/peer_ids.json && ./topos tce status --endpoint http://localhost:1340

--- a/tools/init.sh
+++ b/tools/init.sh
@@ -42,7 +42,7 @@ case "$1" in
         ;;
 
    "peer")
-       if [[ ! -z ${LOCAL_TEST_NET+x} ]]; then
+       if [[ ${LOCAL_TEST_NET:-"false"} == "true" ]]; then
 
            until [ -f "$BOOT_PEERS_PATH" ]
            do


### PR DESCRIPTION
# Description

Fix the docker-compose setup `init` file to be able to launch the cluster locally.
This will be tested on github action soon to avoid regression


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
