### PR TITLE
feat: add push certificate instrumentation event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5635,6 +5635,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "hex",
+ "opentelemetry",
  "rpassword",
  "serde",
  "tokio",
@@ -5707,6 +5708,7 @@ dependencies = [
  "env_logger 0.10.0",
  "fs_extra",
  "hex",
+ "opentelemetry",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rand_distr",
@@ -5725,6 +5727,7 @@ dependencies = [
  "topos-sequencer-types",
  "topos-test-sdk",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "web3",
 ]
@@ -5741,6 +5744,7 @@ dependencies = [
  "futures",
  "hex",
  "hyper",
+ "opentelemetry",
  "rstest 0.16.0",
  "serde",
  "serde_json",

--- a/crates/topos-sequencer-subnet-runtime-proxy/Cargo.toml
+++ b/crates/topos-sequencer-subnet-runtime-proxy/Cargo.toml
@@ -24,6 +24,8 @@ tokio = { workspace = true, features = [
 ] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 tracing.workspace = true
+tracing-opentelemetry.workspace = true
+opentelemetry.workspace = true
 
 topos-core = { workspace = true, features = ["uci"] }
 topos-sequencer-subnet-client = { package = "topos-sequencer-subnet-client", path = "../topos-sequencer-subnet-client" }

--- a/crates/topos-sequencer-subnet-runtime-proxy/src/subnet_runtime_proxy.rs
+++ b/crates/topos-sequencer-subnet-runtime-proxy/src/subnet_runtime_proxy.rs
@@ -220,10 +220,7 @@ impl SubnetRuntimeProxy {
                 } => {
                     let span_subnet_runtime_proxy = info_span!("Subnet Runtime Proxy");
                     span_subnet_runtime_proxy.set_parent(ctx);
-                    let span_push_certificate = info_span!(
-                        parent: &span_subnet_runtime_proxy,
-                        "Subnet push certificate call"
-                    );
+
                     async {
                         info!(
                         "Processing certificate received from TCE, cert_id={}",
@@ -250,6 +247,8 @@ impl SubnetRuntimeProxy {
                                 return;
                             }
                         }
+
+                        let span_push_certificate = info_span!("Subnet push certificate call");
 
                         // Push the Certificate to the ToposCore contract on the target subnet
                         match SubnetRuntimeProxy::push_certificate(

--- a/crates/topos-sequencer-subnet-runtime-proxy/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime-proxy/tests/subnet_contract.rs
@@ -10,7 +10,8 @@ use test_log::test;
 use tokio::sync::oneshot;
 use topos_core::uci::{Certificate, CertificateId};
 use topos_sequencer_types::SubnetId;
-use tracing::{error, info};
+use tracing::{error, info, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 use web3::contract::tokens::Tokenize;
 use web3::ethabi::Token;
 use web3::transports::Http;
@@ -584,10 +585,11 @@ async fn test_subnet_certificate_push_call(
 
     info!("Sending mock certificate to subnet smart contract...");
     if let Err(e) = runtime_proxy_worker.eval(
-        topos_sequencer_types::SubnetRuntimeProxyCommand::OnNewDeliveredCertificate((
-            mock_cert.clone(),
-            0,
-        )),
+        topos_sequencer_types::SubnetRuntimeProxyCommand::OnNewDeliveredCertificate {
+            certificate: mock_cert.clone(),
+            position: 0,
+            ctx: Span::current().context(),
+        },
     ) {
         error!("Failed to send OnNewDeliveredTxns command: {}", e);
         return Err(Box::from(e));

--- a/crates/topos-sequencer-tce-proxy/Cargo.toml
+++ b/crates/topos-sequencer-tce-proxy/Cargo.toml
@@ -32,6 +32,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "json", "ansi
 tracing.workspace = true
 uuid.workspace = true
 tracing-opentelemetry.workspace = true
+opentelemetry.workspace = true
 
 [dev-dependencies]
 topos-tce-transport = { path = "../topos-tce-transport" }

--- a/crates/topos-sequencer-tce-proxy/src/lib.rs
+++ b/crates/topos-sequencer-tce-proxy/src/lib.rs
@@ -517,8 +517,6 @@ impl TceProxyWorker {
                         }
                     }
 
-
-
                      // Process certificates received from the TCE node
                     Some((cert, target_stream_position)) = receiving_certificate_stream.next() => {
                         let span = info_span!("PushCertificate");
@@ -531,7 +529,8 @@ impl TceProxyWorker {
                             .await {
                                 error!("Unable to send NewDeliveredCerts event {e}");
                             }
-                        }.with_context(span.context())
+                        }
+                        .with_context(span.context())
                         .instrument(span)
                         .await;
                     }

--- a/crates/topos-sequencer-types/src/lib.rs
+++ b/crates/topos-sequencer-types/src/lib.rs
@@ -89,7 +89,11 @@ pub enum SubnetRuntimeProxyEvent {
 #[derive(Debug)]
 pub enum SubnetRuntimeProxyCommand {
     /// Upon receiving a new delivered Certificate from the TCE
-    OnNewDeliveredCertificate((Certificate, u64)),
+    OnNewDeliveredCertificate {
+        certificate: Certificate,
+        position: u64,
+        ctx: Context,
+    },
 }
 
 #[derive(Debug)]
@@ -107,7 +111,10 @@ pub enum TceProxyCommand {
 #[derive(Debug, Clone)]
 pub enum TceProxyEvent {
     /// New delivered certificate (and its position) fetched from the TCE network
-    NewDeliveredCerts(Vec<(Certificate, u64)>),
+    NewDeliveredCerts {
+        certificates: Vec<(Certificate, u64)>,
+        ctx: Context,
+    },
     /// Failed watching certificates channel
     /// Requires restart of sequencer tce proxy
     WatchCertificatesChannelFailed,

--- a/crates/topos-sequencer/Cargo.toml
+++ b/crates/topos-sequencer/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { workspace = true, features = ["full"] }
 tracing-subscriber = {workspace = true, features = ["fmt", "std", "env-filter",]}
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
+opentelemetry.workspace = true
 
 topos-crypto.workspace = true
 topos-core = { workspace = true, features = ["uci"] }

--- a/crates/topos-sequencer/src/app_context.rs
+++ b/crates/topos-sequencer/src/app_context.rs
@@ -2,11 +2,12 @@
 //! Application logic glue
 //!
 use crate::SequencerConfiguration;
+use opentelemetry::trace::FutureExt;
 use topos_sequencer_certification::CertificationWorker;
 use topos_sequencer_subnet_runtime_proxy::SubnetRuntimeProxyWorker;
 use topos_sequencer_tce_proxy::TceProxyWorker;
 use topos_sequencer_types::*;
-use tracing::{debug, error, info, info_span, warn, Instrument};
+use tracing::{debug, error, info, info_span, warn, Instrument, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 /// Top-level transducer sequencer app context & driver (alike)
@@ -87,6 +88,7 @@ impl AppContext {
                         cert: Box::new(cert),
                         ctx: span.context(),
                     })
+                    .with_context(span.context())
                     .instrument(span)
                     .await
                 {
@@ -98,13 +100,22 @@ impl AppContext {
 
     async fn on_tce_proxy_event(&mut self, evt: TceProxyEvent) {
         match evt {
-            TceProxyEvent::NewDeliveredCerts(certs) => {
-                // New certificates acquired from TCE
-                for cert in certs {
-                    self.runtime_proxy_worker
-                        .eval(SubnetRuntimeProxyCommand::OnNewDeliveredCertificate(cert))
-                        .expect("Send cross transactions to the runtime");
-                }
+            TceProxyEvent::NewDeliveredCerts { certificates, ctx } => {
+                let span = info_span!("Sequencer app context");
+                span.set_parent(ctx);
+
+                span.in_scope(|| {
+                    // New certificates acquired from TCE
+                    for (cert, cert_position) in certificates {
+                        self.runtime_proxy_worker
+                            .eval(SubnetRuntimeProxyCommand::OnNewDeliveredCertificate {
+                                certificate: cert,
+                                position: cert_position,
+                                ctx: Span::current().context(),
+                            })
+                            .expect("Send cross transactions to the runtime");
+                    }
+                });
             }
             TceProxyEvent::WatchCertificatesChannelFailed => {
                 warn!("Restarting tce proxy worker...");

--- a/crates/topos-sequencer/src/app_context.rs
+++ b/crates/topos-sequencer/src/app_context.rs
@@ -113,7 +113,7 @@ impl AppContext {
                                 position: cert_position,
                                 ctx: Span::current().context(),
                             })
-                            .expect("Send cross transactions to the runtime");
+                            .expect("Propagate new delivered Certificate to the runtime");
                     }
                 });
             }


### PR DESCRIPTION
# Description

Add instrumentation event `PushCertificate`, to mark the submit of the certificate from sequencer to target subnet smart contract.

Fixes TP-327

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
