### PR TITLE
feat: rename TceEvents into ProtocolEvents

### DIFF
--- a/crates/topos-p2p/src/runtime/mod.rs
+++ b/crates/topos-p2p/src/runtime/mod.rs
@@ -115,7 +115,9 @@ impl Runtime {
                         info!("Received peer_info, {event:?}");
                         // Validate peer_info here
                         self.handle(event).await;
-                        if self.peer_set.len() > self.config.minimum_cluster_size {
+                        if addr_query_id.is_none()
+                            && self.peer_set.len() >= self.config.minimum_cluster_size
+                        {
                             let key = Key::new(&self.local_peer_id.to_string());
                             addr_query_id = if let Ok(query_id_record) =
                                 self.swarm.behaviour_mut().discovery.put_record(

--- a/crates/topos-tce-broadcast/src/lib.rs
+++ b/crates/topos-tce-broadcast/src/lib.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc::Sender;
 use tokio::sync::{broadcast, mpsc, oneshot};
 
 use double_echo::DoubleEcho;
-use tce_transport::{ReliableBroadcastParams, TceEvents};
+use tce_transport::{ProtocolEvents, ReliableBroadcastParams};
 
 use topos_core::uci::{Certificate, CertificateId, SubnetId};
 use topos_p2p::PeerId;
@@ -124,7 +124,7 @@ impl ReliableBroadcastClient {
     pub fn new(
         config: ReliableBroadcastConfig,
         local_peer_id: String,
-    ) -> (Self, impl Stream<Item = Result<TceEvents, ()>>) {
+    ) -> (Self, impl Stream<Item = Result<ProtocolEvents, ()>>) {
         let (subscriptions_view_sender, subscriptions_view_receiver) =
             mpsc::channel::<SubscriptionsView>(2048);
         let (subscribers_update_sender, subscribers_update_receiver) =

--- a/crates/topos-tce-broadcast/src/tests/mod.rs
+++ b/crates/topos-tce-broadcast/src/tests/mod.rs
@@ -380,13 +380,10 @@ async fn buffering_certificate(#[case] params: TceParams) {
 
     let mut received_gossip_commands: Vec<(HashSet<PeerId>, Certificate)> = Vec::new();
     let assertion = async {
-        loop {
-            while let Ok(event) = ctx.event_receiver.try_recv() {
-                if let ProtocolEvents::Gossip { peers, cert, .. } = event {
-                    received_gossip_commands.push((peers.into_iter().collect(), cert));
-                }
+        while let Ok(event) = ctx.event_receiver.recv().await {
+            if let ProtocolEvents::Gossip { peers, cert, .. } = event {
+                received_gossip_commands.push((peers.into_iter().collect(), cert));
             }
-            tokio::time::sleep(Duration::from_millis(10)).await;
         }
     };
 

--- a/crates/topos-tce-broadcast/src/tests/mod.rs
+++ b/crates/topos-tce-broadcast/src/tests/mod.rs
@@ -65,7 +65,7 @@ struct TceParams {
 }
 
 struct Context {
-    event_receiver: Receiver<TceEvents>,
+    event_receiver: Receiver<ProtocolEvents>,
     subscribers_update_sender: Sender<SubscribersUpdate>,
     subscriptions_view_sender: Sender<SubscriptionsView>,
     cmd_sender: Sender<DoubleEchoCommand>,
@@ -191,15 +191,15 @@ async fn trigger_success_path_upon_reaching_threshold(#[case] params: TceParams)
 
     assert!(matches!(
         ctx.event_receiver.try_recv(),
-        Ok(TceEvents::Gossip { peers, .. }) if peers.len() == double_echo.gossip_peers().len()
+        Ok(ProtocolEvents::Gossip { peers, .. }) if peers.len() == double_echo.gossip_peers().len()
     ));
     assert!(matches!(
         ctx.event_receiver.try_recv(),
-        Ok(TceEvents::Broadcast { certificate_id }) if certificate_id == dummy_cert.id
+        Ok(ProtocolEvents::Broadcast { certificate_id }) if certificate_id == dummy_cert.id
     ));
     assert!(matches!(
             ctx.event_receiver.try_recv(),
-            Ok(TceEvents::Echo { peers, .. }) if peers.len() == double_echo.subscribers.echo.len()));
+            Ok(ProtocolEvents::Echo { peers, .. }) if peers.len() == double_echo.subscribers.echo.len()));
 
     assert!(matches!(
         ctx.event_receiver.try_recv(),
@@ -214,7 +214,7 @@ async fn trigger_success_path_upon_reaching_threshold(#[case] params: TceParams)
     assert_eq!(ctx.event_receiver.len(), 1);
     assert!(matches!(
         ctx.event_receiver.try_recv(),
-        Ok(TceEvents::Ready { peers, .. }) if peers.len() == double_echo.subscribers.ready.len()
+        Ok(ProtocolEvents::Ready { peers, .. }) if peers.len() == double_echo.subscribers.ready.len()
     ));
 
     // Trigger Delivery upon reaching the Delivery threshold
@@ -224,7 +224,7 @@ async fn trigger_success_path_upon_reaching_threshold(#[case] params: TceParams)
     assert_eq!(ctx.event_receiver.len(), 1);
     assert!(matches!(
          ctx.event_receiver.try_recv(),
-        Ok(TceEvents::CertificateDelivered { certificate }) if certificate == dummy_cert
+        Ok(ProtocolEvents::CertificateDelivered { certificate }) if certificate == dummy_cert
     ));
 }
 
@@ -253,15 +253,15 @@ async fn trigger_ready_when_reached_enough_ready(#[case] params: TceParams) {
     assert_eq!(ctx.event_receiver.len(), 3);
     assert!(matches!(
         ctx.event_receiver.try_recv(),
-        Ok(TceEvents::Gossip { .. })
+        Ok(ProtocolEvents::Gossip { .. })
     ));
     assert!(matches!(
         ctx.event_receiver.try_recv(),
-        Ok(TceEvents::Broadcast { certificate_id }) if certificate_id == dummy_cert.id
+        Ok(ProtocolEvents::Broadcast { certificate_id }) if certificate_id == dummy_cert.id
     ));
     assert!(matches!(
         ctx.event_receiver.try_recv(),
-        Ok(TceEvents::Echo { .. })
+        Ok(ProtocolEvents::Echo { .. })
     ));
 
     // Trigger Ready upon reaching the Ready threshold
@@ -271,7 +271,7 @@ async fn trigger_ready_when_reached_enough_ready(#[case] params: TceParams) {
     assert_eq!(ctx.event_receiver.len(), 1);
     assert!(matches!(
         ctx.event_receiver.try_recv(),
-        Ok(TceEvents::Ready { peers, .. }) if peers.len() == double_echo.subscribers.ready.len()
+        Ok(ProtocolEvents::Ready { peers, .. }) if peers.len() == double_echo.subscribers.ready.len()
     ));
 }
 
@@ -300,15 +300,15 @@ async fn process_after_delivery_until_sending_ready(#[case] params: TceParams) {
     assert_eq!(ctx.event_receiver.len(), 3);
     assert!(matches!(
         ctx.event_receiver.try_recv(),
-        Ok(TceEvents::Gossip { .. })
+        Ok(ProtocolEvents::Gossip { .. })
     ));
     assert!(matches!(
         ctx.event_receiver.try_recv(),
-        Ok(TceEvents::Broadcast { certificate_id }) if certificate_id == dummy_cert.id
+        Ok(ProtocolEvents::Broadcast { certificate_id }) if certificate_id == dummy_cert.id
     ));
     assert!(matches!(
         ctx.event_receiver.try_recv(),
-        Ok(TceEvents::Echo { .. })
+        Ok(ProtocolEvents::Echo { .. })
     ));
 
     // Trigger Delivery upon reaching the Delivery threshold
@@ -321,7 +321,7 @@ async fn process_after_delivery_until_sending_ready(#[case] params: TceParams) {
 
     assert!(matches!(
          ctx.event_receiver.try_recv(),
-        Ok(TceEvents::CertificateDelivered { certificate }) if certificate == dummy_cert
+        Ok(ProtocolEvents::CertificateDelivered { certificate }) if certificate == dummy_cert
     ));
 
     // Trigger Ready upon reaching the Echo threshold
@@ -331,7 +331,7 @@ async fn process_after_delivery_until_sending_ready(#[case] params: TceParams) {
     assert_eq!(ctx.event_receiver.len(), 1);
     assert!(matches!(
         ctx.event_receiver.try_recv(),
-        Ok(TceEvents::Ready { peers, .. }) if peers.len() == double_echo.subscribers.ready.len()
+        Ok(ProtocolEvents::Ready { peers, .. }) if peers.len() == double_echo.subscribers.ready.len()
     ));
 }
 
@@ -382,7 +382,7 @@ async fn buffering_certificate(#[case] params: TceParams) {
     let assertion = async {
         loop {
             while let Ok(event) = ctx.event_receiver.try_recv() {
-                if let TceEvents::Gossip { peers, cert, .. } = event {
+                if let ProtocolEvents::Gossip { peers, cert, .. } = event {
                     received_gossip_commands.push((peers.into_iter().collect(), cert));
                 }
             }

--- a/crates/topos-tce-transport/src/lib.rs
+++ b/crates/topos-tce-transport/src/lib.rs
@@ -114,5 +114,5 @@ pub enum ProtocolEvents {
     CertificateDelivered { certificate: Certificate },
 
     /// Stable Sample
-    StableSample,
+    StableSample(Vec<PeerId>),
 }

--- a/crates/topos-tce-transport/src/lib.rs
+++ b/crates/topos-tce-transport/src/lib.rs
@@ -75,7 +75,7 @@ pub enum TceCommands {
 
 /// Protocol events
 #[derive(Clone, Debug)]
-pub enum TceEvents {
+pub enum ProtocolEvents {
     /// Emitted to get peers list, expected that Commands.ApplyPeers will come as reaction
     NeedPeers,
     /// (pb.Broadcast)

--- a/crates/topos-tce/src/app_context.rs
+++ b/crates/topos-tce/src/app_context.rs
@@ -7,7 +7,7 @@ use futures::{future::join_all, Stream, StreamExt};
 use opentelemetry::trace::{FutureExt as TraceFutureExt, TraceContextExt};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use tce_transport::{TceCommands, TceEvents};
+use tce_transport::{ProtocolEvents, TceCommands};
 use tokio::spawn;
 use tokio::sync::{mpsc, oneshot};
 use topos_core::api::checkpoints::TargetStreamPosition;
@@ -77,7 +77,7 @@ impl AppContext {
     pub async fn run(
         mut self,
         mut network_stream: impl Stream<Item = NetEvent> + Unpin,
-        mut tce_stream: impl Stream<Item = Result<TceEvents, ()>> + Unpin,
+        mut tce_stream: impl Stream<Item = Result<ProtocolEvents, ()>> + Unpin,
         mut api_stream: impl Stream<Item = ApiEvent> + Unpin,
         mut storage_stream: impl Stream<Item = StorageEvent> + Unpin,
         mut synchronizer_stream: impl Stream<Item = SynchronizerEvent> + Unpin,
@@ -247,14 +247,14 @@ impl AppContext {
         }
     }
 
-    async fn on_protocol_event(&mut self, evt: TceEvents) {
+    async fn on_protocol_event(&mut self, evt: ProtocolEvents) {
         match evt {
-            TceEvents::StableSample => {
+            ProtocolEvents::StableSample(peers) => {
                 info!("Stable Sample detected");
                 self.api_client.set_active_sample(true).await;
             }
 
-            TceEvents::Broadcast { certificate_id } => {
+            ProtocolEvents::Broadcast { certificate_id } => {
                 info!("Broadcasting certificate {}", certificate_id);
                 if let Some(messages) = self.buffered_messages.remove(&certificate_id) {
                     let sender = self.tce_cli.get_double_echo_channel();
@@ -265,7 +265,7 @@ impl AppContext {
                 }
             }
 
-            TceEvents::CertificateDelivered { certificate } => {
+            ProtocolEvents::CertificateDelivered { certificate } => {
                 info!("Certificate delivered {}", certificate.id);
                 if let Ok(positions) = self
                     .pending_storage
@@ -302,7 +302,7 @@ impl AppContext {
                 }
             }
 
-            TceEvents::EchoSubscribeReq { peers } => {
+            ProtocolEvents::EchoSubscribeReq { peers } => {
                 // Preparing echo subscribe message
                 let my_peer_id = self.network_client.local_peer_id;
                 let data: Vec<u8> = NetworkMessage::from(TceCommands::OnEchoSubscribeReq {
@@ -364,7 +364,7 @@ impl AppContext {
                     }
                 });
             }
-            TceEvents::ReadySubscribeReq { peers } => {
+            ProtocolEvents::ReadySubscribeReq { peers } => {
                 // Preparing ready subscribe message
                 let my_peer_id = self.network_client.local_peer_id;
                 let data: Vec<u8> = NetworkMessage::from(TceCommands::OnReadySubscribeReq {
@@ -434,7 +434,7 @@ impl AppContext {
                 });
             }
 
-            TceEvents::Gossip {
+            ProtocolEvents::Gossip {
                 peers, cert, ctx, ..
             } => {
                 let span = info_span!(
@@ -477,7 +477,7 @@ impl AppContext {
                 });
             }
 
-            TceEvents::Echo {
+            ProtocolEvents::Echo {
                 peers,
                 certificate_id,
                 ctx,
@@ -520,7 +520,7 @@ impl AppContext {
                 });
             }
 
-            TceEvents::Ready {
+            ProtocolEvents::Ready {
                 peers,
                 certificate_id,
                 ctx,

--- a/crates/topos-tce/src/events.rs
+++ b/crates/topos-tce/src/events.rs
@@ -1,0 +1,5 @@
+use topos_p2p::PeerId;
+
+pub enum Events {
+    StableSample(Vec<PeerId>),
+}

--- a/crates/topos-tce/src/lib.rs
+++ b/crates/topos-tce/src/lib.rs
@@ -15,6 +15,8 @@ use topos_tce_broadcast::{ReliableBroadcastClient, ReliableBroadcastConfig};
 use topos_tce_storage::{Connection, RocksDBStorage};
 use tracing::{debug, info};
 
+pub mod events;
+
 #[derive(Debug)]
 pub struct TceConfiguration {
     pub local_key_seed: Option<Vec<u8>>,
@@ -121,7 +123,7 @@ pub async fn run(
     debug!("gRPC api started");
 
     // setup transport-tce-storage-api connector
-    let app_context = AppContext::new(
+    let (app_context, _tce_stream) = AppContext::new(
         storage_client,
         tce_cli,
         network_client,

--- a/crates/topos-test-sdk/src/tce/protocol.rs
+++ b/crates/topos-test-sdk/src/tce/protocol.rs
@@ -1,14 +1,14 @@
 use futures::Stream;
 
 use topos_tce_broadcast::{ReliableBroadcastClient, ReliableBroadcastConfig};
-use topos_tce_transport::{ReliableBroadcastParams, TceEvents};
+use topos_tce_transport::{ProtocolEvents, ReliableBroadcastParams};
 
 pub fn create_reliable_broadcast_client(
     tce_params: ReliableBroadcastParams,
     peer_id: String,
 ) -> (
     ReliableBroadcastClient,
-    impl Stream<Item = Result<TceEvents, ()>> + Unpin,
+    impl Stream<Item = Result<ProtocolEvents, ()>> + Unpin,
 ) {
     let config = ReliableBroadcastConfig { tce_params };
 

--- a/crates/topos/tests/cert_delivery.rs
+++ b/crates/topos/tests/cert_delivery.rs
@@ -176,7 +176,6 @@ async fn cert_delivery() {
         client_tasks.push(client_task);
     }
 
-    tokio::time::sleep(Duration::from_secs(10)).await;
     // Broadcast multiple certificates from all subnets
     info!("Broadcasting certificates...");
     for (peer_id, client) in peers_context.iter_mut() {


### PR DESCRIPTION
In order to reduce the flakiness of some tests I improved the testability of the TCE by moving some test methods but also exposed a `Receiver<Event>` for the TCE.

## Additions and Changes

- The `wait_for_event` method is now part of the `test-sdk`
- The `topos_tce::AppContext` is exposing a `Receiver<Event>` that will be use to expose event to the runner.
- Removed the `timeout` of the `create_network`, replacing it by a loop over each participant, checking if they received a `StableSample`

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
