### PR TITLE
test: add a new e2e file to github actions

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -1,4 +1,4 @@
-name: Docker_build_push
+name: Docker build and push
 
 on:
   push:

--- a/.github/workflows/docker_utils.yml
+++ b/.github/workflows/docker_utils.yml
@@ -1,4 +1,4 @@
-name: Docker build and push
+name: template - docker
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,49 @@
+name: Execute E2E tests
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Docker build and push"]
+    branches: ["main"]
+    types:
+      - completed
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  EXPECTED_IMAGE_NAME: ghcr.io/${{ github.repository}}:main
+
+jobs:
+
+  docker_local_e2e:
+    name: Docker local check
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    env:
+      PRIV_GH_USER: ${{ secrets.ROBOT_TOPOSWARE_USER }}
+      PRIV_GH_PACKAGE_TOKEN: ${{ secrets.ROBOT_TOPOSWARE_GH_PACKAGE_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.PRIV_GH_USER }}
+          password: ${{ env.PRIV_GH_PACKAGE_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=pr
+
+      - name: Pulling containers
+        run: |
+          docker pull ${{ steps.meta.outputs.tags }}
+          docker tag ${{ steps.meta.outputs.tags}} ${{ env.EXPECTED_IMAGE_NAME }}
+
+      - name: Start containers
+        run: |
+          docker compose -f tools/docker-compose.yml up -d peer


### PR DESCRIPTION
# Description

This PR adds a new github action file to handle the different e2e triggers that we want to execute.
The goal is to execute the e2e after the docker build and push in order to add tests that use those images and doesn't rebuild the entire project locally.

The proper test run will be added in another PR.


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
