### PR TITLE
feat: add CI commands

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -118,5 +118,5 @@ jobs:
               repo: context.repo.repo,
               context: 'e2e-tests',
               sha: '${{ env.head }}',
-              state: '${{ needs.run_command.result }}',
+              state: '${{ needs.run_command.result == 'success' && 'success' || 'failure' }}',
             })

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -65,8 +65,6 @@ jobs:
               state: 'pending',
             })
 
-            console.log(check)
-
       - name: Run test
         run: |
           echo 'run test'
@@ -83,7 +81,7 @@ jobs:
         with:
           github-token: ${{ secrets.TOPOSWARE_CREATE_LABEL }}
           script: |
-            github.rest.issues.addLabels({
+            await github.rest.issues.addLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -65,10 +65,14 @@ jobs:
               state: 'pending',
             })
 
-      - name: Run test
-        run: |
-          echo 'run test'
-        shell: bash
+      - uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: toposware
+          repo: test-commands
+          github_token: ${{ secrets.TOPOSWARE_DISPATCH_WORKFLOW }}
+          workflow_file_name: docker_build_push.yml
+          ref: main
+          client_payload: '{ "git_commit": "${{ env.head }}", "docker_tag": "${{ github.event.issue.number }}" }'
 
   add_label:
     permissions:
@@ -90,6 +94,7 @@ jobs:
 
   checkout:
     needs: run_command
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pull request

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -1,0 +1,119 @@
+name: Run commands when comments added
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: issue-commands-${{ github.event.issue.number }}
+
+jobs:
+  auth:
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    outputs:
+      auth: ${{ steps.auth.outputs.result }}
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+
+      - name: Auth
+        uses: actions/github-script@v6
+        id: auth
+        with:
+          github-token: ${{ secrets.TOPOSWARE_READ_ORG }}
+          result-encoding: string
+          retries: 3
+          # https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+          script: |
+            const resp = await github.rest.orgs.checkMembershipForUser({
+              org: context.repo.owner,
+              username: context.actor,
+            });
+
+            return resp.status == '204';
+
+  run_command:
+    needs: auth
+    # The only supported command is /test
+    if:  needs.auth.outputs.auth == 'true' && github.event.comment.body == '/test'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+
+      - name: Set environment
+        id: env
+        run: |
+          # HEAD of main
+          head="$(git rev-parse HEAD)"
+          echo "head=${head}" >> $GITHUB_ENV
+        shell: bash
+
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const check = await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: 'e2e-tests',
+              sha: '${{ env.head }}',
+              state: 'pending',
+            })
+
+            console.log(check)
+
+      - name: Run test
+        run: |
+          echo 'run test'
+        shell: bash
+
+  add_label:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    needs: run_command
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.TOPOSWARE_CREATE_LABEL }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['ok-to-merge']
+            })
+
+  checkout:
+    needs: run_command
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+
+      - name: Set environment
+        id: env
+        run: |
+          # HEAD of main
+          head="$(git rev-parse HEAD)"
+          echo "head=${head}" >> $GITHUB_ENV
+        shell: bash
+
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const check = await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: 'e2e-tests',
+              sha: '${{ env.head }}',
+              state: '${{ needs.run_command.result }}',
+            })

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -2,14 +2,24 @@ name: Docker_build_push
 
 on:
   push:
-    branches: [main, debug/**]
+    branches: [debug/**]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      git_commit:
+        required: true
+        type: string
+      docker_tag:
+        required: true
+        type: string
 
 jobs:
   docker:
     uses: ./.github/workflows/docker_utils.yml
     secrets: inherit
+    with:
+      tag: "${{ inputs.docker_tag }}"
 
   direct:
     uses: ./.github/workflows/docker_utils.yml
@@ -18,14 +28,14 @@ jobs:
       features: "tce-direct,sequencer"
 
   k8s_e2e:
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'workflow_dispatch' ||  github.event_name == 'push' }}
     runs-on: ubuntu-latest
     needs: docker
     steps:
       - name: Set environment
         run: |
-          # It's fine to assume a single tag. Our tagging strategy follows a 1:1 mapping of image:tag
-          tags=${{ needs.docker.outputs.tags }}
+          # It's fine to assume index 0. The type=raw has higher priority
+          tags=${{ fromJson(steps.meta.outputs.json).tags[0] }}
           echo "docker_tag=${tags#*:}" >> $GITHUB_ENV
         shell: bash
 
@@ -37,4 +47,4 @@ jobs:
           workflow_file_name: test.yml
           ref: main
           wait_interval: 60
-          client_payload: '{ "git_commit": "${{ github.sha }}", "docker_tag": "${{ env.docker_tag }}" }'
+          client_payload: '{ "git_commit": "${{ inputs.git_commit }}", "docker_tag": "${{ env.docker_tag }}" }'

--- a/.github/workflows/docker_utils.yml
+++ b/.github/workflows/docker_utils.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: tce,sequencer
+      tag:
+        required: false
+        type: string
+        default: develop
+
     outputs:
       tags:
         description: "Docker tags"
@@ -75,6 +80,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=raw,prefix=pr-,value=${{ inputs.tag }},suffix=${{ inputs.features == 'tce-direct,sequencer' && '-direct' || ''}}
             type=ref,event=branch,suffix=${{ inputs.features == 'tce-direct,sequencer' && '-direct' || ''}}
             type=ref,event=tag,suffix=${{ inputs.features == 'tce-direct,sequencer' && '-direct' || ''}}
             type=ref,event=pr,suffix=${{ inputs.features == 'tce-direct,sequencer' && '-direct' || ''}}

--- a/.github/workflows/pr-checking.yml
+++ b/.github/workflows/pr-checking.yml
@@ -33,7 +33,6 @@ jobs:
     steps:
       - name: Verify if PR has the "ok-to-merge" label
         uses: actions/github-script@v6
-        id: my-script
         with:
           result-encoding: string
           retries: 3

--- a/.github/workflows/pr-checking.yml
+++ b/.github/workflows/pr-checking.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - edited
       - synchronize
+      - labeled
+      - unlabeled
 
 jobs:
   title:
@@ -24,3 +26,28 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v5
+
+  labels:
+    name: Verify PR labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify if PR has the "ok-to-merge" label
+        uses: actions/github-script@v6
+        id: my-script
+        with:
+          result-encoding: string
+          retries: 3
+          script: |
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            for (const label of labels.data) {
+              if (label.name == 'ok-to-merge') {
+                return;
+              }
+            }
+
+            core.setFailed();


### PR DESCRIPTION
# Description

- Include a slash command to trigger tests such as:
<img width="1232" alt="Screenshot 2023-03-30 at 9 29 25 PM" src="https://user-images.githubusercontent.com/11741977/228993364-ca6e37e0-3409-406d-86c8-dd31f658b7c8.png">

Fixes # (TOO-259)

## Additions and Changes

The overall flow is:
- Merges will be blocked for PRs without the `ok-to-merge` label. This is verified by the `labels` job, in the [pr-checking.yml ](https://github.com/topos-network/topos/blob/e5ae718aecbee318181fc0a31db7e80dd0045b2b/.github/workflows/pr-checking.yml) file
- When a user comments `/test`, the workflow in the [commands.yml](https://github.com/topos-network/topos/blob/e5ae718aecbee318181fc0a31db7e80dd0045b2b/.github/workflows/commands.yml) file will be triggered:
<img width="1241" alt="Screenshot 2023-03-30 at 8 47 18 PM" src="https://user-images.githubusercontent.com/11741977/228996277-b79f88ce-e8d4-4aee-a0c5-83d4ef8b9c30.png">

  - The workflow will verify if it's an authorized user (i.e.: member of `topos-network` org)
  - A status check will be created on the PR status check list
  - The workflow in the [docker_build_push.yml](https://github.com/topos-network/topos/blob/e5ae718aecbee318181fc0a31db7e80dd0045b2b/.github/workflows/docker_build_push.yml) file will be triggered:
    - if it succeeds, the `ok-to-merge` label will be added and the status check will be marked as `success`
    - otherwise it will just mark the status check as `failure`
<img width="1033" alt="Screenshot 2023-03-30 at 8 46 56 PM" src="https://user-images.githubusercontent.com/11741977/228996302-ad03f949-d148-46bd-8ec2-3a078fa2e8d9.png">
<img width="1232" alt="Screenshot 2023-03-30 at 9 41 22 PM" src="https://user-images.githubusercontent.com/11741977/228996316-9e962d27-337c-4eca-a13a-e6c933ea9e23.png">

-  Since the workflow in the [pr-checking.yml ](https://github.com/topos-network/topos/blob/e5ae718aecbee318181fc0a31db7e80dd0045b2b/.github/workflows/pr-checking.yml) file runs whenever a label is added or removed, if the tests succeeds the merge will be unblocked because the `ok-to-merge` label was added


## Breaking changes
- End-to-end tests won't be triggered by merges into `main`
- Merges will be blocked for PRs without the `ok-to-merge` label

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
