### PR TITLE
fix: remove the fixed verion of sequencer tests

### DIFF
--- a/.github/workflows/sequencer_topos_core_contract_test.yml
+++ b/.github/workflows/sequencer_topos_core_contract_test.yml
@@ -27,7 +27,7 @@ jobs:
           - { name: Linux, os: ubuntu-latest, triple: x86_64-unknown-linux-gnu }
         version:
           - stable
-          - nightly-2022-12-18
+          - nightly
 
     name: ${{ matrix.version }} - Deploy smart contracts and test sequencer subnet interaction
     runs-on: ${{ matrix.target.os }}


### PR DESCRIPTION
# Description

The `sequencer` workflow is using an outdated `nightly` version.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
