### PR TITLE
fix: base64 encoding for get last pending certificates

### DIFF
--- a/crates/topos-sequencer-tce-proxy/Cargo.toml
+++ b/crates/topos-sequencer-tce-proxy/Cargo.toml
@@ -33,6 +33,7 @@ tracing.workspace = true
 uuid.workspace = true
 tracing-opentelemetry.workspace = true
 opentelemetry.workspace = true
+base64.workspace = true
 
 [dev-dependencies]
 topos-tce-transport = { path = "../topos-tce-transport" }
@@ -40,7 +41,6 @@ topos-tce = { path = "../topos-tce" }
 rstest = { workspace = true, features = ["async-timeout"] }
 test-log.workspace = true
 env_logger.workspace = true
-base64.workspace = true
 byteorder = "1.4.3"
 dockertest = "0.3.1"
 serial_test = "0.9"

--- a/crates/topos-sequencer-tce-proxy/src/lib.rs
+++ b/crates/topos-sequencer-tce-proxy/src/lib.rs
@@ -3,6 +3,7 @@
 //!
 
 use crate::Error::InvalidChannelError;
+use base64::Engine;
 use opentelemetry::trace::FutureExt;
 use std::collections::HashMap;
 use tokio::sync::{mpsc, oneshot};
@@ -444,7 +445,7 @@ impl TceClientBuilder {
                                                 .into_iter()
                                                 .map(|(subnet_id, last_pending_certificate)| {
                                                     let subnet_id: SubnetId = TryInto::<SubnetId>::try_into(
-                                                        hex::decode(&subnet_id[2..])
+                                                        base64::engine::general_purpose::STANDARD.decode(subnet_id)
                                                             .map_err(|_| Error::InvalidSubnetId)?
                                                             .as_slice(),
                                                     )


### PR DESCRIPTION
# Description

Fix for get last pending certificates

Fixes TP-508


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
