### PR TITLE
fix: remove unneeded optional keyword

### DIFF
--- a/crates/topos-api/proto/topos/uci/v1/certification.proto
+++ b/crates/topos-api/proto/topos/uci/v1/certification.proto
@@ -22,5 +22,5 @@ message Certificate {
 
 
 message OptionalCertificate {
-  optional Certificate value = 1;
+  Certificate value = 1;
 }


### PR DESCRIPTION
# Description

This PR removes an unneeded keyword on one protobuf definition.

Protobuf fields are optional by default, and the keyword is unnecessary in this case.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
