### PR TITLE
feat: topos setup subnet

### DIFF
--- a/.github/workflows/sequencer_topos_core_contract_test.yml
+++ b/.github/workflows/sequencer_topos_core_contract_test.yml
@@ -63,12 +63,12 @@ jobs:
 
       - name: Acquire built smart contracts
         run: |
-          mkdir contracts
+          mkdir -p contracts/topos-core/ToposCore.sol contracts/topos-core/ToposCoreProxy.sol contracts/interfaces/IToposCore.sol contracts/topos-core/TokenDeployer.sol 
           docker create --name dummy ${{ env.REGISTRY }}/${{ env.TOPOS_SMART_CONTRACTS_IMAGE_NAME }}:${{ env.TOPOS_SMART_CONTRACTS_IMAGE_TAG }}
-          docker cp dummy:/usr/src/app/brownie/build/contracts/TokenDeployer.json ./contracts/
-          docker cp dummy:/usr/src/app/brownie/build/contracts/ToposCore.json ./contracts/
-          docker cp dummy:/usr/src/app/brownie/build/contracts/ToposCoreProxy.json ./contracts/
-          docker cp dummy:/usr/src/app/brownie/build/contracts/IToposCore.json ./contracts/
+          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/ToposCore.sol/ToposCore.json ./contracts/topos-core/ToposCore.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/ToposCoreProxy.sol/ToposCoreProxy.json ./contracts/topos-core/ToposCoreProxy.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json ./contracts/interfaces/IToposCore.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/TokenDeployer.sol/TokenDeployer.json ./contracts/topos-core/TokenDeployer.sol/
           docker rm -f dummy
 
       - name: Run all workspace tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",
@@ -2081,9 +2081,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -5444,9 +5444,11 @@ dependencies = [
  "opentelemetry 0.18.0",
  "opentelemetry-otlp 0.11.0",
  "rand 0.8.5",
+ "reqwest",
  "serde",
  "serde_json",
  "test-log",
+ "thiserror",
  "tokio",
  "tonic",
  "topos-certificate-spammer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,8 @@ base64 = { version = "0.21.0"}
 
 # Network related
 backoff = { version = "0.4", features = ["tokio", "futures"] }
-hyper = { version = "0.14", features = ["full"] }
+hyper = { version = "0.14.26", features = ["full"] }
+reqwest = { version = "0.11", features = ["json"] }
 
 # Tests
 rstest = { version = "0.17.0", default-features = false }

--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -24,10 +24,11 @@ use topos_sequencer_subnet_runtime::{SubnetRuntimeProxyConfig, SubnetRuntimeProx
 
 use topos_test_sdk::constants::*;
 
-const SUBNET_TCC_JSON_DEFINITION: &str = "ToposCore.json";
-const SUBNET_TCC_PROXY_JSON_DEFINITION: &str = "ToposCoreProxy.json";
-const SUBNET_ITCC_JSON_DEFINITION: &str = "IToposCore.json";
-const SUBNET_TOKEN_DEPLOYER_JSON_DEFINITION: &str = "TokenDeployer.json";
+const SUBNET_TCC_JSON_DEFINITION: &str = "topos-core/ToposCore.sol/ToposCore.json";
+const SUBNET_TCC_PROXY_JSON_DEFINITION: &str = "topos-core/ToposCoreProxy.sol/ToposCoreProxy.json";
+const SUBNET_ITCC_JSON_DEFINITION: &str = "interfaces/IToposCore.sol/IToposCore.json";
+const SUBNET_TOKEN_DEPLOYER_JSON_DEFINITION: &str =
+    "topos-core/TokenDeployer.sol/TokenDeployer.json";
 const SUBNET_CHAIN_ID: u64 = 100;
 const SUBNET_RPC_PORT: u32 = 8545;
 const TEST_SECRET_ETHEREUM_KEY: &str =

--- a/crates/topos-tce/src/app_context.rs
+++ b/crates/topos-tce/src/app_context.rs
@@ -291,17 +291,17 @@ impl AppContext {
                                 positions
                                     .targets
                                     .into_iter()
-                                    .map(|(subnet_id, ceritificate_target_stream_position)| {
+                                    .map(|(subnet_id, certificate_target_stream_position)| {
                                         (
                                             subnet_id,
                                             TargetStreamPosition {
                                                 target_subnet_id:
-                                                    ceritificate_target_stream_position
+                                                    certificate_target_stream_position
                                                         .target_subnet_id,
                                                 source_subnet_id:
-                                                    ceritificate_target_stream_position
+                                                    certificate_target_stream_position
                                                         .source_subnet_id,
-                                                position: ceritificate_target_stream_position
+                                                position: certificate_target_stream_position
                                                     .position
                                                     .0,
                                                 certificate_id: Some(certificate_id),

--- a/crates/topos/Cargo.toml
+++ b/crates/topos/Cargo.toml
@@ -51,8 +51,6 @@ libp2p = { workspace = true, features = ["identify"] }
 assert_cmd = "2.0.6"
 insta = { version = "1.21", features = ["json", "redactions"] }
 
-
-
 [features]
 default = ["tce", "sequencer", "network", "setup"]
 tce = ["topos-tce", "topos-tce-transport"]

--- a/crates/topos/Cargo.toml
+++ b/crates/topos/Cargo.toml
@@ -29,6 +29,8 @@ tracing-opentelemetry.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "json", "ansi", "fmt"] }
 uuid.workspace = true
 rand.workspace = true
+reqwest.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 topos-tce-broadcast = { path = "../topos-tce-broadcast" }
@@ -49,10 +51,13 @@ libp2p = { workspace = true, features = ["identify"] }
 assert_cmd = "2.0.6"
 insta = { version = "1.21", features = ["json", "redactions"] }
 
+
+
 [features]
-default = ["tce", "sequencer", "network"]
+default = ["tce", "sequencer", "network", "setup"]
 tce = ["topos-tce", "topos-tce-transport"]
 sequencer = ["topos-sequencer"]
 network = ["topos-certificate-spammer"]
+setup = []
 
 tce-direct = ["tce", "topos-tce-broadcast/direct"]

--- a/crates/topos/src/components/mod.rs
+++ b/crates/topos/src/components/mod.rs
@@ -2,5 +2,7 @@
 pub(crate) mod network;
 #[cfg(feature = "sequencer")]
 pub(crate) mod sequencer;
+#[cfg(feature = "setup")]
+pub(crate) mod setup;
 #[cfg(feature = "tce")]
 pub(crate) mod tce;

--- a/crates/topos/src/components/setup/commands.rs
+++ b/crates/topos/src/components/setup/commands.rs
@@ -1,0 +1,29 @@
+use clap::{Args, Subcommand};
+
+mod subnet;
+
+pub(crate) use subnet::Subnet;
+
+#[derive(Args, Debug)]
+pub(crate) struct SetupCommand {
+    #[clap(from_global)]
+    pub(crate) verbose: u8,
+
+    #[clap(subcommand)]
+    pub(crate) subcommands: Option<SetupCommands>,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum SetupCommands {
+    Subnet(Box<Subnet>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run() {
+        assert!(SetupCommands::has_subcommand("subnet"));
+    }
+}

--- a/crates/topos/src/components/setup/commands/subnet.rs
+++ b/crates/topos/src/components/setup/commands/subnet.rs
@@ -6,8 +6,8 @@ use std::path::PathBuf;
 pub struct Subnet {
     /// Installation directory path for Polygon Edge binary.
     /// If not provided, Polygon Edge binary will be installed to the current directory
-    #[clap(long, env = "TOPOS_SETUP_SUBNET_PATH", default_value = ".")]
-    pub path: String,
+    #[clap(long, env = "TOPOS_SETUP_POLYGON_EDGE_DIR", default_value = ".")]
+    pub path: PathBuf,
     /// Polygon Edge release version. If not provided, latest release version will be installed
     #[arg(long, env = "TOPOS_SETUP_SUBNET_RELEASE")]
     pub release: Option<String>,

--- a/crates/topos/src/components/setup/commands/subnet.rs
+++ b/crates/topos/src/components/setup/commands/subnet.rs
@@ -1,0 +1,26 @@
+use clap::Args;
+use std::path::PathBuf;
+
+#[derive(Args, Debug)]
+#[command(about = "Install Polygon Edge node binary")]
+pub struct Subnet {
+    /// Installation directory path for Polygon Edge binary.
+    /// If not provided, Polygon Edge binary will be installed to the current directory
+    #[clap(long, env = "TOPOS_SETUP_SUBNET_PATH", default_value = ".")]
+    pub path: String,
+    /// Polygon Edge release version. If not provided, latest release version will be installed
+    #[arg(long, env = "TOPOS_SETUP_SUBNET_RELEASE")]
+    pub release: Option<String>,
+    /// Polygon Edge Github repository
+    #[arg(
+        long,
+        env = "TOPOS_SETUP_SUBNET_REPOSITORY",
+        default_value = "topos-network/polygon-edge"
+    )]
+    pub repository: String,
+    /// List all available Polygon Edge release versions without installation
+    #[arg(long, action)]
+    pub list_releases: bool,
+}
+
+impl Subnet {}

--- a/crates/topos/src/components/setup/mod.rs
+++ b/crates/topos/src/components/setup/mod.rs
@@ -1,0 +1,56 @@
+use self::commands::{SetupCommand, SetupCommands};
+use tokio::{signal, spawn};
+use tracing::{error, info};
+
+use crate::tracing::setup_tracing;
+
+pub(crate) mod commands;
+
+mod subnet;
+
+pub(crate) async fn handle_command(
+    SetupCommand {
+        subcommands,
+        verbose,
+    }: SetupCommand,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match subcommands {
+        Some(SetupCommands::Subnet(cmd)) => {
+            setup_tracing(verbose, None, None)?;
+
+            spawn(async move {
+                if cmd.list_releases {
+                    info!(
+                        "Retrieving release version list from repository: {}",
+                        &cmd.repository
+                    );
+                    if let Err(e) = subnet::installer::list_polygon_edge_releases(cmd).await {
+                        error!("Error listing Polygon Edge release versions: {e}");
+                        std::process::exit(1);
+                    } else {
+                        std::process::exit(0);
+                    }
+                } else {
+                    info!(
+                        "Starting installation of Polygon Edge binary to target path: {}",
+                        &cmd.path
+                    );
+                    if let Err(e) = subnet::installer::install_polygon_edge(cmd).await {
+                        error!("Error installing Polygon Edge: {e}");
+                        std::process::exit(1);
+                    } else {
+                        info!("Polygon Edge installation successful");
+                        std::process::exit(0);
+                    }
+                }
+            });
+
+            signal::ctrl_c()
+                .await
+                .expect("failed to listen for signals");
+
+            Ok(())
+        }
+        None => Ok(()),
+    }
+}

--- a/crates/topos/src/components/setup/mod.rs
+++ b/crates/topos/src/components/setup/mod.rs
@@ -33,7 +33,7 @@ pub(crate) async fn handle_command(
                 } else {
                     info!(
                         "Starting installation of Polygon Edge binary to target path: {}",
-                        &cmd.path
+                        &cmd.path.display()
                     );
                     if let Err(e) = subnet::installer::install_polygon_edge(cmd).await {
                         error!("Error installing Polygon Edge: {e}");

--- a/crates/topos/src/components/setup/subnet/installer.rs
+++ b/crates/topos/src/components/setup/subnet/installer.rs
@@ -1,0 +1,192 @@
+use crate::components::setup::commands::Subnet;
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::str::FromStr;
+use tokio::{signal, spawn};
+use tracing::{error, info};
+
+const GITHUB_REPO_API: &str = "https://api.github.com/repos/";
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Http client error: {0}")]
+    Http(reqwest::Error),
+    #[error("Json parsing error: {0}")]
+    InvalidJson(serde_json::Error),
+    #[error("There are no available release")]
+    NoValidRelease,
+    #[error("Invalid release metadata")]
+    InvalidReleaseMetadata,
+    #[error("File io error: {0}")]
+    File(std::io::Error),
+}
+
+/// Calculate expected polygon edge binary name for this platform
+/// By convention it is in the format `polygon-edge-<cpu architecture>-<operating system>`
+fn determine_binary_release_name() -> String {
+    "polygon-edge-".to_string() + std::env::consts::ARCH + "-" + std::env::consts::OS
+}
+
+/// Download Polygon Edge binary from repository to requested target directory
+async fn download_binary(file_name: &str, uri: &str, target_directory: &str) -> Result<(), Error> {
+    info!(
+        "Downloading binary `{}` to target directory: {}",
+        file_name, target_directory
+    );
+
+    let response = reqwest::get(uri).await.map_err(Error::Http)?;
+
+    let download_file_name = (target_directory.to_string() + "/" + file_name).replace("\\\\", "\\");
+    let download_file_path = Path::new(&download_file_name);
+    let mut target_file = match File::create(download_file_path) {
+        Err(e) => {
+            error!("Unable to create file: {e}");
+            return Err(Error::File(e));
+        }
+        Ok(file) => file,
+    };
+
+    target_file
+        .write_all(response.bytes().await.map_err(Error::Http)?.as_ref())
+        .map_err(Error::File)?;
+
+    // Set execution rights
+    if let Err(e) = std::process::Command::new("chmod")
+        .arg("u+x")
+        .arg(download_file_name)
+        .output()
+    {
+        error!("Unable to set execution rights for downloaded file: {e}");
+    }
+
+    Ok(())
+}
+
+struct PolygonEdgeRelease {
+    version: String,
+    binary: String,
+    download_url: String,
+}
+
+async fn get_available_releases(repository: &str) -> Result<Vec<PolygonEdgeRelease>, Error> {
+    // Retrieve list of releases
+    let uri = GITHUB_REPO_API.to_string() + repository + "/releases";
+
+    info!("Retrieving Polygon Edge release list {uri}");
+    let client = reqwest::Client::new();
+    let body = client
+        .get(&uri)
+        .header(reqwest::header::USER_AGENT, "Topos CLI")
+        .send()
+        .await
+        .map_err(Error::Http)?
+        .text()
+        .await
+        .map_err(Error::Http)?;
+
+    let body: Vec<Value> = match serde_json::from_str(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            error!("Error parsing release list response: {e}");
+            return Err(Error::InvalidJson(e));
+        }
+    };
+
+    if body.is_empty() {
+        error!("There is no valid Polygon Edge release available");
+        return Err(Error::NoValidRelease);
+    }
+
+    let mut releases: Vec<PolygonEdgeRelease> = Vec::new();
+    // Parse all releases
+    // List of retrieved releases is already sorted, latest release being
+    // the first one in the list
+    for release in &body {
+        let tag_name = release
+            .get("name")
+            .ok_or(Error::InvalidReleaseMetadata)?
+            .to_string()
+            .replace('\"', "");
+
+        let assets = release
+            .get("assets")
+            .ok_or(Error::InvalidReleaseMetadata)?
+            .as_array()
+            .ok_or(Error::InvalidReleaseMetadata)?;
+        for asset in assets {
+            if let Some(name) = asset.get("name").map(|v| v.to_string().replace('\"', "")) {
+                if let Some(url) = asset
+                    .get("browser_download_url")
+                    .map(|v| v.to_string().replace('\"', ""))
+                {
+                    releases.push(PolygonEdgeRelease {
+                        binary: name,
+                        download_url: url,
+                        version: tag_name.clone(),
+                    })
+                }
+            }
+        }
+    }
+
+    Ok(releases)
+}
+
+/// Get list of releases from github repository
+/// Download required release by version, or latest one if desired release was not provided
+async fn get_release(
+    repository: &str,
+    version: &Option<String>,
+) -> Result<PolygonEdgeRelease, Error> {
+    let releases = get_available_releases(repository).await?;
+    let expected_binary = determine_binary_release_name();
+    for release in releases {
+        if let Some(version) = version {
+            if &release.version == version && release.binary == expected_binary {
+                return Ok(release);
+            }
+        } else if release.binary == expected_binary {
+            return Ok(release);
+        }
+    }
+
+    Err(Error::NoValidRelease)
+}
+
+pub async fn install_polygon_edge(cmd: Box<Subnet>) -> Result<(), Error> {
+    // Select release for installation
+    let release = get_release(cmd.repository.as_str(), &cmd.release).await?;
+
+    info!(
+        "Selected release: {} from {}",
+        release.version, release.download_url
+    );
+
+    // Download and install Polygon Edge binary
+    if let Err(e) = download_binary(&release.binary, &release.download_url, &cmd.path).await {
+        error!("Unable to install Polygon Edge binary {e}");
+        return Err(e);
+    }
+
+    Ok(())
+}
+
+pub async fn list_polygon_edge_releases(cmd: Box<Subnet>) -> Result<(), Error> {
+    // Retrieve list of available releases from the Github repository
+    let releases = get_available_releases(&cmd.repository).await?;
+    println!("Available Polygon Edge releases:");
+    releases
+        .into_iter()
+        .map(|r| r.version)
+        .collect::<HashSet<String>>()
+        .iter()
+        .for_each(|r| {
+            println!("   {}", r);
+        });
+
+    Ok(())
+}

--- a/crates/topos/src/components/setup/subnet/mod.rs
+++ b/crates/topos/src/components/setup/subnet/mod.rs
@@ -1,0 +1,1 @@
+pub mod installer;

--- a/crates/topos/src/main.rs
+++ b/crates/topos/src/main.rs
@@ -23,5 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         options::ToposCommand::Sequencer(cmd) => components::sequencer::handle_command(cmd).await,
         #[cfg(feature = "network")]
         options::ToposCommand::Network(cmd) => components::network::handle_command(cmd).await,
+        #[cfg(feature = "setup")]
+        options::ToposCommand::Setup(cmd) => components::setup::handle_command(cmd).await,
     }
 }

--- a/crates/topos/src/options.rs
+++ b/crates/topos/src/options.rs
@@ -9,6 +9,9 @@ use crate::components::tce::commands::TceCommand;
 #[cfg(feature = "network")]
 use crate::components::network::commands::NetworkCommand;
 
+#[cfg(feature = "setup")]
+use crate::components::setup::commands::SetupCommand;
+
 pub(crate) mod input_format;
 
 #[derive(Parser, Debug)]
@@ -35,4 +38,6 @@ pub(crate) enum ToposCommand {
     Sequencer(SequencerCommand),
     #[cfg(feature = "network")]
     Network(NetworkCommand),
+    #[cfg(feature = "setup")]
+    Setup(SetupCommand),
 }


### PR DESCRIPTION
# Description

Add new `topos` cli command to download and install Polygon Edge binary from Github release repository.

Fixes TP-495

## Additions and Changes

Added new CLI command:
```
Install Polygon Edge node binary

Usage: topos setup subnet [OPTIONS]

Options:
      --path <PATH>              Installation directory path for Polygon Edge binary. If not provided, Polygon Edge binary will be installed to the current directory [env: TOPOS_SETUP_SUBNET_PATH=] [default: .]
  -v, --verbose...               Defines the verbosity level
      --release <RELEASE>        Polygon Edge release version. If not provided, latest release version will be installed [env: TOPOS_SETUP_SUBNET_RELEASE=]
      --repository <REPOSITORY>  Polygon Edge Github repository [env: TOPOS_SETUP_SUBNET_REPOSITORY=] [default: topos-network/polygon-edge]
      --list-releases            List all available Polygon Edge release versions without installation
  -h, --help                     Print help

```

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
