### PR TITLE
feat: run polygon edge from topos cli

### DIFF
--- a/crates/topos/Cargo.toml
+++ b/crates/topos/Cargo.toml
@@ -52,10 +52,11 @@ assert_cmd = "2.0.6"
 insta = { version = "1.21", features = ["json", "redactions"] }
 
 [features]
-default = ["tce", "sequencer", "network", "setup"]
+default = ["tce", "sequencer", "network", "setup", "subnet"]
 tce = ["topos-tce", "topos-tce-transport"]
 sequencer = ["topos-sequencer"]
 network = ["topos-certificate-spammer"]
 setup = []
+subnet = []
 
 tce-direct = ["tce", "topos-tce-broadcast/direct"]

--- a/crates/topos/src/components/mod.rs
+++ b/crates/topos/src/components/mod.rs
@@ -4,5 +4,7 @@ pub(crate) mod network;
 pub(crate) mod sequencer;
 #[cfg(feature = "setup")]
 pub(crate) mod setup;
+#[cfg(feature = "subnet")]
+pub(crate) mod subnet;
 #[cfg(feature = "tce")]
 pub(crate) mod tce;

--- a/crates/topos/src/components/network/commands.rs
+++ b/crates/topos/src/components/network/commands.rs
@@ -4,7 +4,7 @@ mod spam;
 
 pub(crate) use spam::Spam;
 
-/// Topos CLI subcommand for using network related functionality,(e.g. running a certificate spammer)
+/// Topos CLI subcommand for network related functionalities (e.g., running the certificate spammer)
 #[derive(Args, Debug)]
 pub(crate) struct NetworkCommand {
     #[clap(from_global)]

--- a/crates/topos/src/components/network/commands.rs
+++ b/crates/topos/src/components/network/commands.rs
@@ -4,6 +4,7 @@ mod spam;
 
 pub(crate) use spam::Spam;
 
+/// Topos CLI subcommand for using network related functionality,(e.g. running a certificate spammer)
 #[derive(Args, Debug)]
 pub(crate) struct NetworkCommand {
     #[clap(from_global)]

--- a/crates/topos/src/components/sequencer/commands.rs
+++ b/crates/topos/src/components/sequencer/commands.rs
@@ -4,7 +4,7 @@ mod run;
 
 pub(crate) use run::Run;
 
-/// Topos CLI subcommand used to execute sequencer component
+/// Topos CLI subcommand for the Sequencer components
 #[derive(Args, Debug)]
 pub(crate) struct SequencerCommand {
     #[clap(from_global)]

--- a/crates/topos/src/components/sequencer/commands.rs
+++ b/crates/topos/src/components/sequencer/commands.rs
@@ -4,6 +4,7 @@ mod run;
 
 pub(crate) use run::Run;
 
+/// Topos CLI subcommand used to execute sequencer component
 #[derive(Args, Debug)]
 pub(crate) struct SequencerCommand {
     #[clap(from_global)]

--- a/crates/topos/src/components/setup/commands.rs
+++ b/crates/topos/src/components/setup/commands.rs
@@ -4,6 +4,7 @@ mod subnet;
 
 pub(crate) use subnet::Subnet;
 
+/// Topos CLI subcommand used for setup of various Topos related components (e.g. installation of Polygon Edge binary)
 #[derive(Args, Debug)]
 pub(crate) struct SetupCommand {
     #[clap(from_global)]

--- a/crates/topos/src/components/setup/commands.rs
+++ b/crates/topos/src/components/setup/commands.rs
@@ -4,7 +4,7 @@ mod subnet;
 
 pub(crate) use subnet::Subnet;
 
-/// Topos CLI subcommand used for setup of various Topos related components (e.g. installation of Polygon Edge binary)
+/// Topos CLI subcommand for the setup of various Topos related components (e.g., installation of Polygon Edge binary)
 #[derive(Args, Debug)]
 pub(crate) struct SetupCommand {
     #[clap(from_global)]

--- a/crates/topos/src/components/subnet/commands.rs
+++ b/crates/topos/src/components/subnet/commands.rs
@@ -1,0 +1,30 @@
+use clap::{Args, Subcommand};
+
+mod subnet;
+
+pub(crate) use subnet::Run;
+
+/// Topos CLI subcommand used to utilize subnet (Polygon Edge) related functionality
+#[derive(Args, Debug)]
+pub(crate) struct SubnetCommand {
+    #[clap(from_global)]
+    pub(crate) verbose: u8,
+
+    #[clap(subcommand)]
+    pub(crate) subcommands: Option<SubnetCommands>,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum SubnetCommands {
+    Run(Run),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run() {
+        assert!(SubnetCommands::has_subcommand("run"));
+    }
+}

--- a/crates/topos/src/components/subnet/commands.rs
+++ b/crates/topos/src/components/subnet/commands.rs
@@ -4,7 +4,7 @@ mod subnet;
 
 pub(crate) use subnet::Run;
 
-/// Topos CLI subcommand used to utilize subnet (Polygon Edge) related functionality
+/// Topos CLI subcommand for the Polygon Edge related functionalities
 #[derive(Args, Debug)]
 pub(crate) struct SubnetCommand {
     #[clap(from_global)]

--- a/crates/topos/src/components/subnet/commands/subnet.rs
+++ b/crates/topos/src/components/subnet/commands/subnet.rs
@@ -1,0 +1,17 @@
+use clap::{ArgGroup, Args, Parser};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[clap(about = "Run Polygon Edge", trailing_var_arg = true)]
+pub struct Run {
+    /// Installation directory path for Polygon Edge binary.
+    /// If not provided, Polygon Edge binary will be expected in the current directory
+    #[arg(long, env = "TOPOS_SUBNET_PATH", default_value = ".")]
+    pub path: String,
+
+    /// Polygon Edge command line arguments
+    #[clap(allow_hyphen_values = true)]
+    pub polygon_edge_arguments: Vec<String>,
+}
+
+impl Run {}

--- a/crates/topos/src/components/subnet/commands/subnet.rs
+++ b/crates/topos/src/components/subnet/commands/subnet.rs
@@ -6,8 +6,8 @@ use std::path::PathBuf;
 pub struct Run {
     /// Installation directory path for Polygon Edge binary.
     /// If not provided, Polygon Edge binary will be expected in the current directory
-    #[arg(long, env = "TOPOS_SUBNET_PATH", default_value = ".")]
-    pub path: String,
+    #[arg(long, env = "TOPOS_POLYGON_EDGE_BIN_PATH", default_value = ".")]
+    pub path: PathBuf,
 
     /// Polygon Edge command line arguments
     #[clap(allow_hyphen_values = true)]

--- a/crates/topos/src/components/subnet/mod.rs
+++ b/crates/topos/src/components/subnet/mod.rs
@@ -21,11 +21,12 @@ pub(crate) async fn handle_command(
 
             let binary_name =
                 "polygon-edge-".to_string() + std::env::consts::ARCH + "-" + std::env::consts::OS;
-            let polygon_edge_path = cmd.path.to_string() + "/" + &binary_name;
+            let polygon_edge_path = cmd.path.join(&binary_name);
 
             info!(
                 "Running binary {} with arguments:{:?}",
-                polygon_edge_path, cmd.polygon_edge_arguments
+                polygon_edge_path.display(),
+                cmd.polygon_edge_arguments
             );
 
             spawn(async move {
@@ -37,10 +38,14 @@ pub(crate) async fn handle_command(
                     .stdin(Stdio::inherit())
                     .spawn()
                 {
-                    Ok(command) => {
-                        if let Some(pid) = command.id() {
-                            info!("Child process with pid {pid} successfully started");
+                    Ok(mut child) => {
+                        if let Some(pid) = child.id() {
+                            info!("Polygon Edge child process with pid {pid} successfully started");
                         }
+                        if let Err(e) = child.wait().await {
+                            info!("Polygon Edge child process finished with error: {e}");
+                        }
+                        std::process::exit(0);
                     }
                     Err(e) => {
                         error!("Error executing Polygon Edge: {e}");

--- a/crates/topos/src/components/subnet/mod.rs
+++ b/crates/topos/src/components/subnet/mod.rs
@@ -1,0 +1,60 @@
+use self::commands::{Run, SubnetCommand, SubnetCommands};
+use clap::Parser;
+use std::process::Stdio;
+use tokio::{io::AsyncReadExt, io::BufReader, process, process::Command};
+use tokio::{signal, spawn};
+use tracing::{error, info};
+
+use crate::tracing::setup_tracing;
+
+pub(crate) mod commands;
+
+pub(crate) async fn handle_command(
+    SubnetCommand {
+        subcommands,
+        verbose,
+    }: SubnetCommand,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match subcommands {
+        Some(SubnetCommands::Run(cmd)) => {
+            setup_tracing(verbose, None, None)?;
+
+            let binary_name =
+                "polygon-edge-".to_string() + std::env::consts::ARCH + "-" + std::env::consts::OS;
+            let polygon_edge_path = cmd.path.to_string() + "/" + &binary_name;
+
+            info!(
+                "Running binary {} with arguments:{:?}",
+                polygon_edge_path, cmd.polygon_edge_arguments
+            );
+
+            spawn(async move {
+                // Run Polygon Edge command. Pass all parameters.
+                match Command::new(polygon_edge_path)
+                    .args(cmd.polygon_edge_arguments)
+                    .stderr(Stdio::inherit())
+                    .stdout(Stdio::inherit())
+                    .stdin(Stdio::inherit())
+                    .spawn()
+                {
+                    Ok(command) => {
+                        if let Some(pid) = command.id() {
+                            info!("Child process with pid {pid} successfully started");
+                        }
+                    }
+                    Err(e) => {
+                        error!("Error executing Polygon Edge: {e}");
+                        std::process::exit(1);
+                    }
+                }
+            });
+
+            signal::ctrl_c()
+                .await
+                .expect("failed to listen for signals");
+
+            Ok(())
+        }
+        None => Ok(()),
+    }
+}

--- a/crates/topos/src/components/tce/commands.rs
+++ b/crates/topos/src/components/tce/commands.rs
@@ -21,7 +21,7 @@ pub(crate) struct NodeArgument {
     pub(crate) node: String,
 }
 
-/// Topos CLI subcommand used to execute TCE related functionality
+/// Topos CLI subcommand for the TCE related functionalities
 #[derive(Args, Debug)]
 pub(crate) struct TceCommand {
     #[clap(from_global)]

--- a/crates/topos/src/components/tce/commands.rs
+++ b/crates/topos/src/components/tce/commands.rs
@@ -21,6 +21,7 @@ pub(crate) struct NodeArgument {
     pub(crate) node: String,
 }
 
+/// Topos CLI subcommand used to execute TCE related functionality
 #[derive(Args, Debug)]
 pub(crate) struct TceCommand {
     #[clap(from_global)]

--- a/crates/topos/src/main.rs
+++ b/crates/topos/src/main.rs
@@ -25,5 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         options::ToposCommand::Network(cmd) => components::network::handle_command(cmd).await,
         #[cfg(feature = "setup")]
         options::ToposCommand::Setup(cmd) => components::setup::handle_command(cmd).await,
+        #[cfg(feature = "subnet")]
+        options::ToposCommand::Subnet(cmd) => components::subnet::handle_command(cmd).await,
     }
 }

--- a/crates/topos/src/options.rs
+++ b/crates/topos/src/options.rs
@@ -12,6 +12,9 @@ use crate::components::network::commands::NetworkCommand;
 #[cfg(feature = "setup")]
 use crate::components::setup::commands::SetupCommand;
 
+#[cfg(feature = "subnet")]
+use crate::components::subnet::commands::SubnetCommand;
+
 pub(crate) mod input_format;
 
 #[derive(Parser, Debug)]
@@ -40,4 +43,6 @@ pub(crate) enum ToposCommand {
     Network(NetworkCommand),
     #[cfg(feature = "setup")]
     Setup(SetupCommand),
+    #[cfg(feature = "subnet")]
+    Subnet(SubnetCommand),
 }


### PR DESCRIPTION
# Description

Add additional topos cli command `subnet run` which runs `Polygon Edge` node as a subprocess

Fixes TP-408

## Additions and Changes

Polygon Edge sub-process inherits standard input and output from topos cli process. When executed, to shut it down press `ctrl+C`

```
Run Polygon Edge

Usage: topos subnet run [OPTIONS] [POLYGON_EDGE_ARGUMENTS]...

Arguments:
  [POLYGON_EDGE_ARGUMENTS]...  Command line to start child process

Options:
      --path <PATH>  Installation directory path for Polygon Edge binary. If not provided, Polygon Edge binary will be expected in the current directory [env: TOPOS_SUBNET_PATH=] [default: .]
  -v, --verbose...   Defines the verbosity level
  -h, --help         Print help
```

For example to print Polygon Edge options, execute:
```
topos subnet run -- --help
```

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
