### PR TITLE
feat: replace TokenSent event with CrossSubnetMessageSent

### DIFF
--- a/crates/topos-sequencer-subnet-client/abi/IToposCore.json
+++ b/crates/topos-sequencer-subnet-client/abi/IToposCore.json
@@ -37,6 +37,19 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": false,
+        "internalType": "SubnetId",
+        "name": "targetSubnetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "CrossSubnetMessageSent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": true,
         "internalType": "address",
         "name": "implementation",
@@ -114,6 +127,19 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "SubnetId",
+        "name": "targetSubnetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "emitCrossSubnetMessage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/crates/topos-sequencer-subnet-client/src/lib.rs
+++ b/crates/topos-sequencer-subnet-client/src/lib.rs
@@ -24,13 +24,8 @@ pub type Hash = String;
 /// Event collected from the sending subnet
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SubnetEvent {
-    TokenSent {
-        sender: Address,
-        source_subnet_id: SubnetId,
+    CrossSubnetMessageSent {
         target_subnet_id: SubnetId,
-        receiver: Address,
-        symbol: String,
-        amount: ethereum_types::U256,
     },
     ContractCall {
         source_subnet_id: SubnetId,

--- a/crates/topos-sequencer-subnet-runtime/src/certification.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/certification.rs
@@ -56,7 +56,7 @@ impl Certification {
             let mut target_subnets: Vec<SubnetId> = Vec::new();
             for event in &block_info.events {
                 match event {
-                    SubnetEvent::TokenSent {
+                    SubnetEvent::CrossSubnetMessageSent {
                         target_subnet_id, ..
                     } => {
                         target_subnets.push(*target_subnet_id);


### PR DESCRIPTION
# Description

With the messaging features of `ToposCore` now extracted into a new `ToposMessaging` contract, the current logic for the sequencer process to capture events linked to cross-subnet messages must be updated.

This PR updates the sequencer so that it consumes new `CrossSubnetMessageSent` events emitted by `ToposCore`.

## Additions and Changes

- Update `ToposCore` ABI
- Replace the decoding of `TokenSent` events by the one of `CrossSubnetMessageSent` events
- Update the decoding to solely decode the `targetSubnetId` field (other fields weren't used beforehand anyway)

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
