### PR TITLE
chore: add cache mount for sccache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ WORKDIR /usr/src/app
 FROM base AS build
 COPY . .
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
-  cargo build --release --no-default-features --features=${FEATURES}
+    --mount=type=cache,id=sccache,target=/root/.cache/sccache \
+  cargo build --release --no-default-features --features=${FEATURES} \
+  && sccache --show-stats
 
 FROM debian:bullseye-slim AS topos
 


### PR DESCRIPTION
# Description

At the moment, caching capabilities using [sccache with S3](https://github.com/mozilla/sccache/blob/main/docs/S3.md) are only available for the CI workflow.

With this pull request, caching for local builds will be available, similar to what is done for CI workflows. However, instead of using S3, [Docker cache mounts](https://docs.docker.com/build/cache/) are utilized to store and retrieve cached objects.

Fixes # (TOO-290)

## Additions and Changes

To enable the usage of `sccache`, the argument `RUSTC_WRAPPER` needs to be set to `/usr/local/cargo/bin/sccache`:
```
$ docker build . \
    --tag topos \
    --progress=plain \
    --build-arg TOOLCHAIN_VERSION=stable \
    --build-arg FEATURES=tce,sequencer,network \
    --build-arg RUSTC_WRAPPER=/usr/local/cargo/bin/sccache
```

First local build:
<img width="1155" alt="Screenshot 2023-05-04 at 11 46 39 AM" src="https://user-images.githubusercontent.com/11741977/236244799-92f92bd3-05dd-4b09-81b8-8fa565151923.png">

Build using cache:
<img width="1155" alt="Screenshot 2023-05-04 at 11 49 53 AM" src="https://user-images.githubusercontent.com/11741977/236244874-24945e10-e84b-4818-9c5e-03eeb0d7370c.png">


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
