### PR TITLE
ci: add new grpc js client stubs generation CI workflow

### DIFF
--- a/.github/workflows/grpc-client-stubs.yml
+++ b/.github/workflows/grpc-client-stubs.yml
@@ -1,0 +1,45 @@
+name: JS gRPC client stubs generation
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  js-grpc:
+    name: JS gRPC client stubs generation
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+          cache-dependency-path: ./crates/topos-api/proto/package-lock.json
+          registry-url: https://registry.npmjs.org
+          scope: "@topos-network"
+
+      - name: Install grpc-tool globally
+        run: npm install -g grpc-tools
+
+      - name: Generate client stubs
+        working-directory: ./crates/topos-api/proto
+        run: >
+          mkdir generated &&
+          grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./generated --grpc_out=grpc_js:./generated topos/shared/v1/certificate.proto &&
+          grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./generated --grpc_out=grpc_js:./generated topos/shared/v1/checkpoints.proto &&
+          grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./generated --grpc_out=grpc_js:./generated topos/shared/v1/frost.proto &&
+          grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./generated --grpc_out=grpc_js:./generated topos/shared/v1/stark_proof.proto &&
+          grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./generated --grpc_out=grpc_js:./generated topos/shared/v1/subnet.proto &&
+          grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./generated --grpc_out=grpc_js:./generated topos/shared/v1/uuid.proto &&
+          grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./generated --grpc_out=grpc_js:./generated topos/uci/v1/certification.proto &&
+          grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./generated --grpc_out=grpc_js:./generated topos/tce/v1/api.proto &&
+          grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./generated --grpc_out=grpc_js:./generated topos/tce/v1/console.proto &&
+          grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./generated --grpc_out=grpc_js:./generated topos/tce/v1/synchronization.proto
+
+      - name: Publish npm package
+        working-directory: ./crates/topos-api/proto
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,5 +61,3 @@ jobs:
       - run: cargo nextest run cert_delivery --locked --no-default-features -F tce
         env:
           RUST_LOG: topos=info
-
-

--- a/crates/topos-api/proto/package-lock.json
+++ b/crates/topos-api/proto/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@topos-network/topos-grpc-client-stub",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@topos-network/topos-grpc-client-stub",
+      "version": "1.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/crates/topos-api/proto/package.json
+++ b/crates/topos-api/proto/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@topos-network/topos-grpc-client-stub",
+  "version": "0.1.0-rc2",
+  "description": "JavaScript gRPC client stub for topos-api",
+  "files": [
+    "generated"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/topos-network/topos.git"
+  },
+  "keywords": [
+    "grpc",
+    "api",
+    "topos",
+    "client",
+    "stub",
+    "javascript"
+  ],
+  "author": "Sebastien Dan <sebastien.dan@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/topos-network/topos/issues"
+  },
+  "homepage": "https://github.com/topos-network/topos#readme"
+}


### PR DESCRIPTION
# Description

This PR adds JavaScript client stub generation and packaging in a [@topos-network/topos-grpc-client-stub](https://www.npmjs.com/package/@topos-network/topos-grpc-client-stub) npm package.

Client stubs can then be used in web applications for interactions with the gRPC API of a `topos` node.

## Additions and Changes

- Add `package.json` and `package-lock.json` files in the `proto` directory to identify and version the npm package
- Add a CI workflow to generate stubs and package them in a new package to be published

**Note: Packages are built and published on new Github `releases`. It's important to remember that the version of the package (specified in its `package.json` file) needs to be updated priori to the creation of the release on Github (otherwise package publication will fail and the release will have to be recreated).**

Tagging @Freyskeyd @atanmarko @hadjiszs @gruberb to double-check this point above ⬆️ 

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
