### PR TITLE
ci: generate ts typings for grpc client stub

### DIFF
--- a/.github/workflows/grpc-client-stubs.yml
+++ b/.github/workflows/grpc-client-stubs.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Check if npm package version has been updated
         id: check
+        working-directory: ./crates/topos-api/proto
         uses: EndBug/version-check@v2
 
       - name: Publish npm package

--- a/.github/workflows/grpc-client-stubs.yml
+++ b/.github/workflows/grpc-client-stubs.yml
@@ -1,8 +1,14 @@
 name: gRPC client stubs generation
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
+    paths:
+      - "**.proto"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**.proto"
 
 jobs:
   js-grpc:
@@ -50,7 +56,12 @@ jobs:
         run: >
           protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated -I . $(find ./topos -name '*.proto')
 
+      - name: Check if npm package version has been updated
+        id: check
+        uses: EndBug/version-check@v2
+
       - name: Publish npm package
+        if: steps.check.outputs.changed == 'true' && ${{ github.event_name == 'push' }} && ${{ github.ref == 'refs/heads/main' }}
         working-directory: ./crates/topos-api/proto
         run: npm publish --access public
         env:

--- a/.github/workflows/grpc-client-stubs.yml
+++ b/.github/workflows/grpc-client-stubs.yml
@@ -58,8 +58,9 @@ jobs:
 
       - name: Check if npm package version has been updated
         id: check
-        working-directory: ./crates/topos-api/proto
         uses: EndBug/version-check@v2
+        with:
+          file-name: ./crates/topos-api/proto/package.json
 
       - name: Publish npm package
         if: steps.check.outputs.changed == 'true' && ${{ github.event_name == 'push' }} && ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/grpc-client-stubs.yml
+++ b/.github/workflows/grpc-client-stubs.yml
@@ -61,9 +61,18 @@ jobs:
         uses: EndBug/version-check@v2
         with:
           file-name: ./crates/topos-api/proto/package.json
+          file-url: https://unpkg.com/@topos-network/topos-grpc-client-stub@latest/package.json
+          static-checking: localIsNew
+
+      - name: Check coverage tolerance
+        if: steps.check.outputs.changed == 'false'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Protobuf files were updated but npm package version was not bumped!')
 
       - name: Publish npm package
-        if: steps.check.outputs.changed == 'true' && ${{ github.event_name == 'push' }} && ${{ github.ref == 'refs/heads/main' }}
+        if: steps.check.outputs.changed == 'true' && github.event_name == 'push'
         working-directory: ./crates/topos-api/proto
         run: npm publish --access public
         env:

--- a/.github/workflows/grpc-client-stubs.yml
+++ b/.github/workflows/grpc-client-stubs.yml
@@ -1,4 +1,4 @@
-name: JS gRPC client stubs generation
+name: gRPC client stubs generation
 
 on:
   release:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   js-grpc:
-    name: JS gRPC client stubs generation
+    name: JavaScript gRPC client stubs generation
     runs-on: ubuntu-latest
 
     steps:
@@ -48,16 +48,7 @@ jobs:
       - name: Generate TypeScript typings
         working-directory: ./crates/topos-api/proto
         run: >
-          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/shared/v1/certificate.proto &&
-          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/shared/v1/checkpoints.proto &&
-          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/shared/v1/frost.proto &&
-          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/shared/v1/stark_proof.proto &&
-          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/shared/v1/subnet.proto &&
-          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/shared/v1/uuid.proto &&
-          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/uci/v1/certification.proto &&
-          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/tce/v1/api.proto &&
-          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/tce/v1/console.proto &&
-          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/tce/v1/synchronization.proto
+          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated -I . $(find ./topos -name '*.proto')
 
       - name: Publish npm package
         working-directory: ./crates/topos-api/proto

--- a/.github/workflows/grpc-client-stubs.yml
+++ b/.github/workflows/grpc-client-stubs.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install protoc
+        run: sudo apt update && sudo apt install -y protobuf-compiler
+
       - uses: actions/setup-node@v3
         with:
           node-version: 16
@@ -22,6 +25,10 @@ jobs:
 
       - name: Install grpc-tool globally
         run: npm install -g grpc-tools
+
+      - name: Install npm packages
+        working-directory: ./crates/topos-api/proto
+        run: npm ci
 
       - name: Generate client stubs
         working-directory: ./crates/topos-api/proto
@@ -37,6 +44,20 @@ jobs:
           grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./generated --grpc_out=grpc_js:./generated topos/tce/v1/api.proto &&
           grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./generated --grpc_out=grpc_js:./generated topos/tce/v1/console.proto &&
           grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./generated --grpc_out=grpc_js:./generated topos/tce/v1/synchronization.proto
+
+      - name: Generate TypeScript typings
+        working-directory: ./crates/topos-api/proto
+        run: >
+          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/shared/v1/certificate.proto &&
+          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/shared/v1/checkpoints.proto &&
+          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/shared/v1/frost.proto &&
+          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/shared/v1/stark_proof.proto &&
+          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/shared/v1/subnet.proto &&
+          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/shared/v1/uuid.proto &&
+          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/uci/v1/certification.proto &&
+          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/tce/v1/api.proto &&
+          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/tce/v1/console.proto &&
+          protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./generated topos/tce/v1/synchronization.proto
 
       - name: Publish npm package
         working-directory: ./crates/topos-api/proto

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ terraform.rc
 
 # Subnet integration tests
 crates/topos-sequencer-subnet-runtime/tests/temp
+
+# Node modules
+**/node_modules

--- a/crates/topos-api/proto/package-lock.json
+++ b/crates/topos-api/proto/package-lock.json
@@ -1,13 +1,161 @@
 {
   "name": "@topos-network/topos-grpc-client-stub",
-  "version": "1.0.0",
+  "version": "0.1.0-rc2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@topos-network/topos-grpc-client-stub",
+      "version": "0.1.0-rc2",
+      "license": "MIT",
+      "devDependencies": {
+        "grpc_tools_node_protoc_ts": "^5.3.3"
+      }
+    },
+    "node_modules/google-protobuf": {
+      "version": "3.15.8",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.15.8.tgz",
+      "integrity": "sha512-2jtfdqTaSxk0cuBJBtTTWsot4WtR9RVr2rXg7x7OoqiuOKopPrwXpM1G4dXIkLcUNRh3RKzz76C8IOkksZSeOw==",
+      "dev": true
+    },
+    "node_modules/grpc_tools_node_protoc_ts": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/grpc_tools_node_protoc_ts/-/grpc_tools_node_protoc_ts-5.3.3.tgz",
+      "integrity": "sha512-M/YrklvVXMtuuj9kb42PxeouZhs7Ul+R4e/31XwrankUcKL8cQQP50Q9q+KEHGyHQaPt6VtKKsxMgLaKbCxeww==",
+      "dev": true,
+      "dependencies": {
+        "google-protobuf": "3.15.8",
+        "handlebars": "4.7.7"
+      },
+      "bin": {
+        "protoc-gen-ts": "bin/protoc-gen-ts"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/wordwrap": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "google-protobuf": {
+      "version": "3.15.8",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.15.8.tgz",
+      "integrity": "sha512-2jtfdqTaSxk0cuBJBtTTWsot4WtR9RVr2rXg7x7OoqiuOKopPrwXpM1G4dXIkLcUNRh3RKzz76C8IOkksZSeOw==",
+      "dev": true
+    },
+    "grpc_tools_node_protoc_ts": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/grpc_tools_node_protoc_ts/-/grpc_tools_node_protoc_ts-5.3.3.tgz",
+      "integrity": "sha512-M/YrklvVXMtuuj9kb42PxeouZhs7Ul+R4e/31XwrankUcKL8cQQP50Q9q+KEHGyHQaPt6VtKKsxMgLaKbCxeww==",
+      "dev": true,
+      "requires": {
+        "google-protobuf": "3.15.8",
+        "handlebars": "4.7.7"
+      }
+    },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
+    "minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     }
   }
 }

--- a/crates/topos-api/proto/package.json
+++ b/crates/topos-api/proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topos-network/topos-grpc-client-stub",
-  "version": "0.1.0-rc2",
+  "version": "0.1.0-rc3",
   "description": "JavaScript gRPC client stub for topos-api",
   "files": [
     "generated"
@@ -22,5 +22,8 @@
   "bugs": {
     "url": "https://github.com/topos-network/topos/issues"
   },
-  "homepage": "https://github.com/topos-network/topos#readme"
+  "homepage": "https://github.com/topos-network/topos#readme",
+  "devDependencies": {
+    "grpc_tools_node_protoc_ts": "^5.3.3"
+  }
 }

--- a/crates/topos-api/proto/package.json
+++ b/crates/topos-api/proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topos-network/topos-grpc-client-stub",
-  "version": "0.1.0-rc3",
+  "version": "0.1.1",
   "description": "JavaScript gRPC client stub for topos-api",
   "files": [
     "generated"

--- a/crates/topos-api/proto/topos/tce/v1/synchronization.proto
+++ b/crates/topos-api/proto/topos/tce/v1/synchronization.proto
@@ -16,7 +16,7 @@ message CheckpointRequest {
     Heads heads = 2;
     // This type of request will ask for the same position for every subnet
     SamePosition same_position = 3;
-    // This type of request will ask for the zero position for every subnets
+    // This type of request will ask for the zero position for every subnet
     Zero zero = 4;
   }
 

--- a/crates/topos-api/proto/topos/tce/v1/synchronization.proto
+++ b/crates/topos-api/proto/topos/tce/v1/synchronization.proto
@@ -14,7 +14,7 @@ message CheckpointRequest {
   oneof request_type {
     // This type of request will ask for heads of subnets
     Heads heads = 2;
-    // This type of request will ask for the same position for every subnets
+    // This type of request will ask for the same position for every subnet
     SamePosition same_position = 3;
     // This type of request will ask for the zero position for every subnets
     Zero zero = 4;

--- a/crates/topos-api/proto/topos/tce/v1/synchronization.proto
+++ b/crates/topos-api/proto/topos/tce/v1/synchronization.proto
@@ -16,7 +16,7 @@ message CheckpointRequest {
     Heads heads = 2;
     // This type of request will ask for the same position for every subnet
     SamePosition same_position = 3;
-    // This type of request will ask for the zero position for every subnet
+    // This type of request will ask for the zero position for every subnets
     Zero zero = 4;
   }
 


### PR DESCRIPTION
# Description

#229 introduced JavaScript gRPC client stubs generation through a new CI workflow. This PR adds the generation of TypeScript typings so that TypeScript clients can better use our client stubs.

Additionally, this PR changes the npm package publication flow to the following one:
- First of all, the CI workflow will only run when
  - the push on `main` contains changes to protobuf files
  - the PR contains changes to protobuf files (coming from the active update or previous ones)
- On PR updates, a step will check whether the npm package version was bumped and make the job fail if not
- On merge on `main`, the `npm publish` step is run if the above was successful

Testing this new logic:
- [run](https://github.com/topos-network/topos/actions/runs/5072802220) that shows a failure because of missing version bump
- [run](https://github.com/topos-network/topos/actions/runs/5072886924/jobs/9111190112#step:9:20) that shows a success because version was bumped

## Additions and Changes

- Add the `grpc_tools_node_protoc_ts` npm package as dep
- Install `protoc` in the CI workflow
- Use `protoc` with a bin packaged in `grpc_tools_node_protoc_ts` to generate typings
- Bump npm package version to `0.1.1`

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
