### PR TITLE
fix: sccache credentials

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -92,10 +92,6 @@ runs:
         SCCACHE_REGION=us-east-1
         EOF
 
-    - name: Run sccache-cache
-      if: ${{ inputs.with_cache == 'true' }}
-      uses: mozilla-actions/sccache-action@v0.0.3
-
     - name: Configure AWS credentials for cicd-devnet-1 account
       uses: aws-actions/configure-aws-credentials@v2
       with:
@@ -113,6 +109,10 @@ runs:
         aws configure set aws_access_key_id ${{ env.AWS_ACCESS_KEY_ID }} --profile default
         aws configure set aws_secret_access_key ${{ env.AWS_SECRET_ACCESS_KEY }} --profile default
         aws configure set aws_session_token ${{ env.AWS_SESSION_TOKEN }} --profile default
+
+    - name: Run sccache-cache
+      if: ${{ inputs.with_cache == 'true' }}
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - uses: taiki-e/install-action@v2
       with:


### PR DESCRIPTION
# Description

Sccache requires a number of [env vars](https://github.com/mozilla/sccache/blob/main/docs/S3.md#s3) to be set in order to function correctly.

AWS offers different options to configure credentials. [Assuming IAM roles](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) is one of them.

In this PR the order of steps were changed to fix auth errors, such as:
```
The authorization header is malformed; a non-empty Access Key (AKID) must be provided in the credential.
```

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
