### PR TITLE
ci: build multi-platform docker images

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     uses: ./.github/workflows/docker_utils.yml
@@ -96,5 +100,3 @@ jobs:
           ref: main
           wait_interval: 60
           client_payload: '{ "git_commit": "${{ github.sha }}", "docker_tag": "${{ env.docker_tag }}" }'
-
-

--- a/.github/workflows/docker_utils.yml
+++ b/.github/workflows/docker_utils.yml
@@ -84,6 +84,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           # push only images targeting topos (e.g.: exclude test, lint, etc.)
           push: ${{ inputs.target == 'topos' }}
           target: ${{ inputs.target }}

--- a/.github/workflows/docker_utils.yml
+++ b/.github/workflows/docker_utils.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG TOOLCHAIN_VERSION
-FROM ghcr.io/topos-network/rust_builder:bullseye-${TOOLCHAIN_VERSION} AS base
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/topos-network/rust_builder:bullseye-${TOOLCHAIN_VERSION} AS base
 
 ARG FEATURES
 # Rust cache
@@ -10,14 +10,14 @@ ARG RUSTC_WRAPPER
 
 WORKDIR /usr/src/app
 
-FROM base AS build
+FROM --platform=${BUILDPLATFORM:-linux/amd64} base AS build
 COPY . .
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
     --mount=type=cache,id=sccache,target=/root/.cache/sccache \
   cargo build --release --no-default-features --features=${FEATURES} \
   && sccache --show-stats
 
-FROM debian:bullseye-slim AS topos
+FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:bullseye-slim AS topos
 
 ENV TCE_PORT=9090
 ENV USER=topos


### PR DESCRIPTION
# Description

Docker images are only built with the default `linux/amd64` platform. This PR adds the `linux/arm64` platform to add support for arm based architectures (e.g., Apple Silicon macs).

## Additions and Changes

### New feature (non-breaking change which adds functionality)
- Specify explicitly platforms to be used as target in the docker-build-push community Github Action
- Add explicit `BUILDPLATFORM` references in Dockerfile

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
