### PR TITLE
chore: use filesystem abi files for smart contract tests

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -28,6 +28,12 @@ jobs:
   lint:
     name: Lint - Clippy
     runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      PRIV_GH_USER: ${{ secrets.ROBOT_TOPOSWARE_USER }}
+      PRIV_GH_PACKAGE_TOKEN: ${{ secrets.ROBOT_TOPOSWARE_GH_PACKAGE_TOKEN }}
+      TOPOS_SMART_CONTRACTS_IMAGE_NAME: topos-network/topos-smart-contracts
+      TOPOS_SMART_CONTRACTS_IMAGE_TAG: main
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -37,6 +43,35 @@ jobs:
           components: clippy
           AWS_ACCESS_KEY_ID: ${{ secrets.ROBOT_AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ROBOT_AWS_SECRET_ACCESS_KEY}}
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ env.PRIV_GH_USER }}
+          password: ${{ env.PRIV_GH_PACKAGE_TOKEN }}
+
+      - name: Pull images
+        run: |
+          docker pull ${{ env.REGISTRY }}/${{ env.TOPOS_SMART_CONTRACTS_IMAGE_NAME }}:${{ env.TOPOS_SMART_CONTRACTS_IMAGE_TAG }}
+
+      - name: Acquire built smart contracts
+        run: |
+          mkdir -p artifacts/contracts/topos-core/TokenDeployer.sol  artifacts/contracts/topos-core/ToposCore.sol artifacts/contracts/topos-core/ToposCoreProxy.sol artifacts/contracts/topos-core/ToposMessaging.sol/
+          mkdir -p artifacts/contracts/examples/ERC20Messaging.sol/ artifacts/contracts/interfaces/IERC20Messaging.sol/ artifacts/contracts/interfaces/IToposCore.sol artifacts/contracts/interfaces/IToposMessaging.sol/ 
+          docker create --name dummy ${{ env.REGISTRY }}/${{ env.TOPOS_SMART_CONTRACTS_IMAGE_NAME }}:${{ env.TOPOS_SMART_CONTRACTS_IMAGE_TAG }}
+          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/TokenDeployer.sol/TokenDeployer.json ./artifacts/contracts/topos-core/TokenDeployer.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/ToposCore.sol/ToposCore.json ./artifacts/contracts/topos-core/ToposCore.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/ToposCoreProxy.sol/ToposCoreProxy.json ./artifacts/contracts/topos-core/ToposCoreProxy.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/ToposMessaging.sol/ToposMessaging.json ./artifacts/contracts/topos-core/ToposMessaging.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/examples/ERC20Messaging.sol/ERC20Messaging.json ./artifacts/contracts/examples/ERC20Messaging.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json ./artifacts/contracts/interfaces/IToposCore.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/interfaces/IToposMessaging.sol/IToposMessaging.json ./artifacts/contracts/interfaces/IToposMessaging.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/interfaces/IERC20Messaging.sol/IERC20Messaging.json ./artifacts/contracts/interfaces/IERC20Messaging.sol/
+          docker rm -f dummy          
 
       - name: Cargo xclippy
         run: cargo xclippy

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -29,14 +29,15 @@ jobs:
     name: Lint - Clippy
     runs-on: ubuntu-latest
     env:
-      REGISTRY: ghcr.io
-      PRIV_GH_USER: ${{ secrets.ROBOT_TOPOSWARE_USER }}
-      PRIV_GH_PACKAGE_TOKEN: ${{ secrets.ROBOT_TOPOSWARE_GH_PACKAGE_TOKEN }}
+      CARGO_TERM_COLOR: always
+      RUSTFLAGS: -Dwarnings
+      RUST_BACKTRACE: 1
     steps:
-      - name: Checkout
+      - name: Checkout topos repo
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/install-rust
+      - name: Install Rust
+        uses: ./.github/actions/install-rust
         with:
           components: clippy
           AWS_ACCESS_KEY_ID: ${{ secrets.ROBOT_AWS_ACCESS_KEY_ID}}
@@ -44,13 +45,6 @@ jobs:
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ env.PRIV_GH_USER }}
-          password: ${{ env.PRIV_GH_PACKAGE_TOKEN }}
 
       - name: Checkout topos-smart-contracts repo
         uses: actions/checkout@v3
@@ -75,7 +69,7 @@ jobs:
         run: npm run build
 
       - name: Move contract artifacts
-        run: mv contracts/artifacts ./artifacts
+        run: mv contracts/artifacts ./
 
       - name: Cargo xclippy
         run: cargo xclippy

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -32,8 +32,6 @@ jobs:
       REGISTRY: ghcr.io
       PRIV_GH_USER: ${{ secrets.ROBOT_TOPOSWARE_USER }}
       PRIV_GH_PACKAGE_TOKEN: ${{ secrets.ROBOT_TOPOSWARE_GH_PACKAGE_TOKEN }}
-      TOPOS_SMART_CONTRACTS_IMAGE_NAME: topos-network/topos-smart-contracts
-      TOPOS_SMART_CONTRACTS_IMAGE_TAG: main
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -54,24 +52,30 @@ jobs:
           username: ${{ env.PRIV_GH_USER }}
           password: ${{ env.PRIV_GH_PACKAGE_TOKEN }}
 
-      - name: Pull images
-        run: |
-          docker pull ${{ env.REGISTRY }}/${{ env.TOPOS_SMART_CONTRACTS_IMAGE_NAME }}:${{ env.TOPOS_SMART_CONTRACTS_IMAGE_TAG }}
+      - name: Checkout topos-smart-contracts repo
+        uses: actions/checkout@v3
+        with:
+          repository: topos-network/topos-smart-contracts
+          ref: ${{ env.CONTRACTS_REF }}
+          path: contracts
 
-      - name: Acquire built smart contracts
-        run: |
-          mkdir -p artifacts/contracts/topos-core/TokenDeployer.sol  artifacts/contracts/topos-core/ToposCore.sol artifacts/contracts/topos-core/ToposCoreProxy.sol artifacts/contracts/topos-core/ToposMessaging.sol/
-          mkdir -p artifacts/contracts/examples/ERC20Messaging.sol/ artifacts/contracts/interfaces/IERC20Messaging.sol/ artifacts/contracts/interfaces/IToposCore.sol artifacts/contracts/interfaces/IToposMessaging.sol/ 
-          docker create --name dummy ${{ env.REGISTRY }}/${{ env.TOPOS_SMART_CONTRACTS_IMAGE_NAME }}:${{ env.TOPOS_SMART_CONTRACTS_IMAGE_TAG }}
-          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/TokenDeployer.sol/TokenDeployer.json ./artifacts/contracts/topos-core/TokenDeployer.sol/
-          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/ToposCore.sol/ToposCore.json ./artifacts/contracts/topos-core/ToposCore.sol/
-          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/ToposCoreProxy.sol/ToposCoreProxy.json ./artifacts/contracts/topos-core/ToposCoreProxy.sol/
-          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/ToposMessaging.sol/ToposMessaging.json ./artifacts/contracts/topos-core/ToposMessaging.sol/
-          docker cp dummy:/usr/src/app/artifacts/contracts/examples/ERC20Messaging.sol/ERC20Messaging.json ./artifacts/contracts/examples/ERC20Messaging.sol/
-          docker cp dummy:/usr/src/app/artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json ./artifacts/contracts/interfaces/IToposCore.sol/
-          docker cp dummy:/usr/src/app/artifacts/contracts/interfaces/IToposMessaging.sol/IToposMessaging.json ./artifacts/contracts/interfaces/IToposMessaging.sol/
-          docker cp dummy:/usr/src/app/artifacts/contracts/interfaces/IERC20Messaging.sol/IERC20Messaging.json ./artifacts/contracts/interfaces/IERC20Messaging.sol/
-          docker rm -f dummy          
+      - name: Set up NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "npm"
+          cache-dependency-path: contracts/package-lock.json
+
+      - name: Install dependencies
+        working-directory: contracts
+        run: npm ci
+
+      - name: Build contracts
+        working-directory: contracts
+        run: npm run build
+
+      - name: Move contract artifacts
+        run: mv contracts/artifacts ./artifacts
 
       - name: Cargo xclippy
         run: cargo xclippy

--- a/.github/workflows/sequencer_topos_core_contract_test.yml
+++ b/.github/workflows/sequencer_topos_core_contract_test.yml
@@ -2,81 +2,20 @@ name: Sequencer Topos Core Contract interaction test
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
-env:
-  CARGO_TERM_COLOR: always
-  RUSTFLAGS: -Dwarnings
-  RUST_BACKTRACE: 1
-  # Change to specific Rust release to pin
-  rust_clippy: 1.62.1
-  REGISTRY: ghcr.io
-  POLYGON_SUBNET_IMAGE_NAME: topos-network/polygon-edge
-  POLYGON_SUBNET_IMAGE_TAG: develop
-  TOPOS_SMART_CONTRACTS_IMAGE_NAME: topos-network/topos-smart-contracts
-  TOPOS_SMART_CONTRACTS_IMAGE_TAG: main
-
 jobs:
-  deploy_smart_contracts_test_subnet_interaction:
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - { name: Linux, os: ubuntu-latest, triple: x86_64-unknown-linux-gnu }
-        version:
-          - stable
-          - nightly
-
-    name: ${{ matrix.version }} - Deploy smart contracts and test sequencer subnet interaction
-    runs-on: ${{ matrix.target.os }}
-    env:
-      PRIV_GH_USER: ${{ secrets.ROBOT_TOPOSWARE_USER }}
-      PRIV_GH_PACKAGE_TOKEN: ${{ secrets.ROBOT_TOPOSWARE_GH_PACKAGE_TOKEN }}
+  sequencer-contracts-e2e:
+    runs-on: ubuntu-latest-16-core
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Install Rust ${{ matrix.version }}
-        uses: actions-rs/toolchain@v1
+      - uses: convictional/trigger-workflow-and-wait@v1.6.1
         with:
-          toolchain: ${{ matrix.version }}
-          components:
-          override: true
-
-      - uses: Swatinem/rust-cache@v1
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ env.PRIV_GH_USER }}
-          password: ${{ env.PRIV_GH_PACKAGE_TOKEN }}
-
-      - name: Pull images
-        run: |
-          docker pull ${{ env.REGISTRY }}/${{ env.POLYGON_SUBNET_IMAGE_NAME }}:${{ env.POLYGON_SUBNET_IMAGE_TAG }}
-          docker pull ${{ env.REGISTRY }}/${{ env.TOPOS_SMART_CONTRACTS_IMAGE_NAME }}:${{ env.TOPOS_SMART_CONTRACTS_IMAGE_TAG }}
-
-      - name: Acquire built smart contracts
-        run: |
-          mkdir -p artifacts/contracts/topos-core/TokenDeployer.sol  artifacts/contracts/topos-core/ToposCore.sol artifacts/contracts/topos-core/ToposCoreProxy.sol artifacts/contracts/topos-core/ToposMessaging.sol/
-          mkdir -p artifacts/contracts/examples/ERC20Messaging.sol/ artifacts/contracts/interfaces/IERC20Messaging.sol/ artifacts/contracts/interfaces/IToposCore.sol  artifacts/contracts/interfaces/IToposMessaging.sol/ 
-          docker create --name dummy ${{ env.REGISTRY }}/${{ env.TOPOS_SMART_CONTRACTS_IMAGE_NAME }}:${{ env.TOPOS_SMART_CONTRACTS_IMAGE_TAG }}
-          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/TokenDeployer.sol/TokenDeployer.json ./artifacts/contracts/topos-core/TokenDeployer.sol/
-          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/ToposCore.sol/ToposCore.json ./artifacts/contracts/topos-core/ToposCore.sol/
-          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/ToposCoreProxy.sol/ToposCoreProxy.json ./artifacts/contracts/topos-core/ToposCoreProxy.sol/
-          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/ToposMessaging.sol/ToposMessaging.json ./artifacts/contracts/topos-core/ToposMessaging.sol/
-          docker cp dummy:/usr/src/app/artifacts/contracts/examples/ERC20Messaging.sol/ERC20Messaging.json ./artifacts/contracts/examples/ERC20Messaging.sol/
-          docker cp dummy:/usr/src/app/artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json ./artifacts/contracts/interfaces/IToposCore.sol/
-          docker cp dummy:/usr/src/app/artifacts/contracts/interfaces/IToposMessaging.sol/IToposMessaging.json ./artifacts/contracts/interfaces/IToposMessaging.sol/
-          docker cp dummy:/usr/src/app/artifacts/contracts/interfaces/IERC20Messaging.sol/IERC20Messaging.json ./artifacts/contracts/interfaces/IERC20Messaging.sol/
-          docker rm -f dummy          
-
-      - name: Run all workspace tests
-        run: |
-          cd crates/topos-sequencer-subnet-runtime
-          cargo test -- --nocapture
+          owner: topos-network
+          repo: e2e-tests
+          github_token: ${{ secrets.ROBOT_PAT_TRIGGER_E2E_WORKFLOWS }}
+          workflow_file_name: topos:sequencer-contracts.yml
+          ref: main
+          wait_interval: 60
+          client_payload: '{ "topos-ref": "${{ github.head_ref }}" }'

--- a/.github/workflows/sequencer_topos_core_contract_test.yml
+++ b/.github/workflows/sequencer_topos_core_contract_test.yml
@@ -2,7 +2,7 @@ name: Sequencer Topos Core Contract interaction test
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
   workflow_dispatch:
 
@@ -59,6 +59,22 @@ jobs:
       - name: Pull images
         run: |
           docker pull ${{ env.REGISTRY }}/${{ env.POLYGON_SUBNET_IMAGE_NAME }}:${{ env.POLYGON_SUBNET_IMAGE_TAG }}
+          docker pull ${{ env.REGISTRY }}/${{ env.TOPOS_SMART_CONTRACTS_IMAGE_NAME }}:${{ env.TOPOS_SMART_CONTRACTS_IMAGE_TAG }}
+
+      - name: Acquire built smart contracts
+        run: |
+          mkdir -p artifacts/contracts/topos-core/TokenDeployer.sol  artifacts/contracts/topos-core/ToposCore.sol artifacts/contracts/topos-core/ToposCoreProxy.sol artifacts/contracts/topos-core/ToposMessaging.sol/
+          mkdir -p artifacts/contracts/examples/ERC20Messaging.sol/ artifacts/contracts/interfaces/IERC20Messaging.sol/ artifacts/contracts/interfaces/IToposCore.sol  artifacts/contracts/interfaces/IToposMessaging.sol/ 
+          docker create --name dummy ${{ env.REGISTRY }}/${{ env.TOPOS_SMART_CONTRACTS_IMAGE_NAME }}:${{ env.TOPOS_SMART_CONTRACTS_IMAGE_TAG }}
+          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/TokenDeployer.sol/TokenDeployer.json ./artifacts/contracts/topos-core/TokenDeployer.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/ToposCore.sol/ToposCore.json ./artifacts/contracts/topos-core/ToposCore.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/ToposCoreProxy.sol/ToposCoreProxy.json ./artifacts/contracts/topos-core/ToposCoreProxy.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/topos-core/ToposMessaging.sol/ToposMessaging.json ./artifacts/contracts/topos-core/ToposMessaging.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/examples/ERC20Messaging.sol/ERC20Messaging.json ./artifacts/contracts/examples/ERC20Messaging.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json ./artifacts/contracts/interfaces/IToposCore.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/interfaces/IToposMessaging.sol/IToposMessaging.json ./artifacts/contracts/interfaces/IToposMessaging.sol/
+          docker cp dummy:/usr/src/app/artifacts/contracts/interfaces/IERC20Messaging.sol/IERC20Messaging.json ./artifacts/contracts/interfaces/IERC20Messaging.sol/
+          docker rm -f dummy          
 
       - name: Run all workspace tests
         run: |

--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -46,14 +46,39 @@ const CERTIFICATE_ID_3: CertificateId = CERTIFICATE_ID_8;
 const DEFAULT_GAS: u64 = 5_000_000;
 
 //TODO I haven't find a way to parametrize version, macro accepts strictly string literal
-abigen!(TokenDeployerContract, "npm:@topos-network/topos-smart-contracts@latest/artifacts/contracts/topos-core/TokenDeployer.sol/TokenDeployer.json");
-abigen!(ToposCoreContract, "npm:@topos-network/topos-smart-contracts@latest/artifacts/contracts/topos-core/ToposCore.sol/ToposCore.json");
-abigen!(ToposCoreProxyContract, "npm:@topos-network/topos-smart-contracts@latest/artifacts/contracts/topos-core/ToposCoreProxy.sol/ToposCoreProxy.json");
-abigen!(ToposMessagingContract, "npm:@topos-network/topos-smart-contracts@latest/artifacts/contracts/topos-core/ToposMessaging.sol/ToposMessaging.json");
-abigen!(ERC20MessagingContract, "npm:@topos-network/topos-smart-contracts@latest/artifacts/contracts/examples/ERC20Messaging.sol/ERC20Messaging.json");
-abigen!(IToposCore, "npm:@topos-network/topos-smart-contracts@latest/artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json");
-abigen!(IToposMessaging, "npm:@topos-network/topos-smart-contracts@latest/artifacts/contracts/interfaces/IToposMessaging.sol/IToposMessaging.json");
-abigen!(IERC20Messaging, "npm:@topos-network/topos-smart-contracts@latest/artifacts/contracts/interfaces/IERC20Messaging.sol/IERC20Messaging.json");
+// `topos-smart-contracts` build artifacts directory must be copied to the root topos directory to run these tests
+abigen!(
+    TokenDeployerContract,
+    "./artifacts/contracts/topos-core/TokenDeployer.sol/TokenDeployer.json"
+);
+abigen!(
+    ToposCoreContract,
+    "./artifacts/contracts/topos-core/ToposCore.sol/ToposCore.json"
+);
+abigen!(
+    ToposCoreProxyContract,
+    "./artifacts/contracts/topos-core/ToposCoreProxy.sol/ToposCoreProxy.json"
+);
+abigen!(
+    ToposMessagingContract,
+    "./artifacts/contracts/topos-core/ToposMessaging.sol/ToposMessaging.json"
+);
+abigen!(
+    ERC20MessagingContract,
+    "./artifacts/contracts/examples/ERC20Messaging.sol/ERC20Messaging.json"
+);
+abigen!(
+    IToposCore,
+    "./artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json"
+);
+abigen!(
+    IToposMessaging,
+    "./artifacts/contracts/interfaces/IToposMessaging.sol/IToposMessaging.json"
+);
+abigen!(
+    IERC20Messaging,
+    "./artifacts/contracts/interfaces/IERC20Messaging.sol/IERC20Messaging.json"
+);
 
 abigen!(
     IERC20,


### PR DESCRIPTION
# Description

Sequencer smart contract integration tests require `topos-smart-contracts` build artifacts folder in the `topos` root.

Fixes TP-628

## Breaking changes

Tests would not work without artifacts folder in the `topos` root

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
